### PR TITLE
[Frontend] Feature: Bridge Function to open a microapp from a microapp (with data)

### DIFF
--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -18,6 +18,7 @@ import { Colors } from "@/constants/Colors";
 import {
   DEVELOPER_APP_ANDROID_DEFAULT_URL,
   DEVELOPER_APP_IOS_DEFAULT_URL,
+  DOWNLOADED,
   FULL_SCREEN_VIEWING_MODE,
   GOOGLE_ANDROID_CLIENT_ID,
   GOOGLE_IOS_CLIENT_ID,
@@ -86,6 +87,7 @@ const MicroApp = () => {
     appId,
     displayMode,
     version,
+    launchData,
   } = useLocalSearchParams<MicroAppParams>();
   const { bottom: bottomSafeArea } = useSafeAreaInsets();
 
@@ -99,6 +101,7 @@ const MicroApp = () => {
     isIos ? DEVELOPER_APP_IOS_DEFAULT_URL : DEVELOPER_APP_ANDROID_DEFAULT_URL
   );
   const colorScheme = useColorScheme();
+  const apps = useSelector((state: RootState) => state.apps.apps);
   const appScopes = useSelector(
     (state: RootState) => state.appConfig.appScopes
   );
@@ -507,6 +510,60 @@ const MicroApp = () => {
     sendResponseToWeb("resolveMicroAppVersion", version || "unknown");
   };
 
+  // Function to open another micro app
+  const handleOpenMicroApp = async (targetAppId: string, data: any) => {
+    const targetApp = apps.find((app) => app.appId === targetAppId);
+    if (targetApp?.status === DOWNLOADED) {
+      router.push({
+        pathname: ScreenPaths.MICRO_APP,
+        params: {
+          webViewUri: targetApp.webViewUri,
+          appName: targetApp.name,
+          clientId: targetApp.clientId,
+          exchangedToken: targetApp.exchangedToken,
+          appId: targetApp.appId,
+          displayMode: targetApp.displayMode,
+          launchData: JSON.stringify(data),
+        },
+      });
+    } else {
+      Alert.alert(
+        "App not installed",
+        "Would you like to install it?",
+        [
+          {
+            text: "Cancel",
+            style: "cancel",
+            onPress: () => {},
+          },
+          {
+            text: "Install",
+            onPress: () => {
+              router.back();
+              router.navigate(ScreenPaths.STORE);
+            },
+          },
+        ],
+        { cancelable: false }
+      );
+    }
+  };
+
+  // Function to get launch data passed to the micro app
+  const handleGetLaunchData = async () => {
+    if (launchData) {
+      try {
+        const parsedData = JSON.parse(launchData);
+        sendResponseToWeb("resolveGetLaunchData", parsedData);
+      } catch (error) {
+        console.error("Failed to parse launch data:", error);
+        sendResponseToWeb("resolveGetLaunchData", launchData);
+      }
+    } else {
+      sendResponseToWeb("resolveGetLaunchData", null);
+    }
+  };
+
   // Handle messages from WebView
   const onMessage = async (event: WebViewMessageEvent) => {
     try {
@@ -594,6 +651,12 @@ const MicroApp = () => {
           break;
         case TOPIC.MICRO_APP_VERSION:
           handleMicroAppVersion();
+          break;
+        case TOPIC.OPEN_MICRO_APP:
+          await handleOpenMicroApp(data.appId, data.data);
+          break;
+        case TOPIC.GET_LAUNCH_DATA:
+          await handleGetLaunchData();
           break;
         default:
           console.error("Unknown topic:", topic);

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -26,6 +26,7 @@ export type MicroAppParams = {
   appId: string;
   displayMode?: DisplayMode;
   version?: string;
+  launchData?: string;
 };
 
 export type DisplayMode =

--- a/frontend/utils/bridge.ts
+++ b/frontend/utils/bridge.ts
@@ -41,6 +41,8 @@ export const TOPIC = {
   DEVICE_SCREEN_SIZE: "device_screen_size",
   OPEN_URL: "open_url",
   MICRO_APP_VERSION: "micro_app_version",
+  OPEN_MICRO_APP: "open_micro_app",
+  GET_LAUNCH_DATA: "get_launch_data",
 };
 
 // JavaScript code injected into the WebView to enable communication between
@@ -118,5 +120,8 @@ export const injectedJavaScript = `window.nativebridge = {
     rejectOpenUrl: (err) => console.error("Failed to open URL:", err),
     requestMicroAppVersion: () => window.ReactNativeWebView.postMessage(JSON.stringify({ topic: "micro_app_version" })),
     resolveMicroAppVersion: (version) => console.log("Micro App Version:", version),
-    rejectMicroAppVersion: (err) => console.error("Failed to get Micro App version:", err)
+    rejectMicroAppVersion: (err) => console.error("Failed to get Micro App version:", err),
+    requestOpenMicroApp: (appId, data) => window.ReactNativeWebView.postMessage(JSON.stringify({ topic: "open_micro_app", data: { appId, data } })),
+    requestGetLaunchData: () => window.ReactNativeWebView.postMessage(JSON.stringify({ topic: "get_launch_data" })),
+    resolveGetLaunchData: (data) => console.log("Launch Data:", data)
   };`;


### PR DESCRIPTION
### Description

This PR implements a new native bridge function that enables microapps to launch each other and pass context data via serialized JSON. This allows one microapp to open another and transfer dynamic data during the launch of the other microapp.

#### Usage on microapps

```typescript
// Source app launches target app with data
window.nativebridge.requestOpenMicroApp('target-app-id', { userId: '123', action: 'edit' }); 

// Target microapp retrieves launch data on initialization
window.nativebridge.resolveGetLaunchData = (data) => {
  callback(data);
};
// Callback receives: { userId: '123', action: 'edit' }
```

Note: Data is serialized to keep the data dynamic to cater for any microapp. The handling of the data should be done on the microapp.

### Screen recordings

#### Success flow

https://github.com/user-attachments/assets/d1917b2a-31c2-4be0-b646-71142bdac4d7


#### Non-existing (Not downloaded) microapp
https://github.com/user-attachments/assets/7aa91053-b862-4249-8bf1-e566c2c64598 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now launch other micro apps directly from within an app
  * Missing app installations trigger a prompt directing users to the store
  * Apps can pass initial data when launching other micro apps

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->