### PR TITLE
[Frontend] Bugfix: Fix Android store and notification icons not pressable issue

### DIFF
--- a/frontend/app/(tabs)/apps/_layout.tsx
+++ b/frontend/app/(tabs)/apps/_layout.tsx
@@ -25,6 +25,7 @@ import { useEffect, useRef } from "react";
 import {
   Animated,
   Easing,
+  Pressable,
   TouchableOpacity,
   useColorScheme,
   View,
@@ -67,7 +68,7 @@ export default function AppsStack() {
         Animated.delay(120),
         singleShake,
         Animated.delay(2200),
-      ])
+      ]),
     );
 
     loopAnimation.start();
@@ -94,7 +95,8 @@ export default function AppsStack() {
               style={{ flexDirection: "row", alignItems: "center", gap: 24 }}
             >
               <TouchableOpacity
-                onPress={() => router.push(ScreenPaths.STORE)}
+                onPressIn={() => router.push(ScreenPaths.STORE)}
+                delayPressIn={0}
                 hitSlop={20}
               >
                 <Ionicons
@@ -106,7 +108,8 @@ export default function AppsStack() {
 
               {accessToken ? (
                 <TouchableOpacity
-                  onPress={() => router.push(ScreenPaths.NOTIFICATIONS)}
+                  onPressIn={() => router.push(ScreenPaths.NOTIFICATIONS)}
+                  delayPressIn={0}
                   hitSlop={20}
                 >
                   <View>


### PR DESCRIPTION
### Description

This pull request makes small improvements to the navigation responsiveness in the `AppsStack` component. The main change is updating the navigation buttons to respond more quickly to user interaction by using `onPressIn` instead of `onPress`, along with setting `delayPressIn={0}`. Additionally, there is a minor import update.


https://github.com/user-attachments/assets/388b9d04-1110-47f2-b771-17ba842e4d4e



- Navigation responsiveness improvements:
  * Changed the navigation buttons for the store and notifications to use `onPressIn` instead of `onPress`, and set `delayPressIn={0}` in both cases, making the navigation react immediately when the user presses down. (`frontend/app/(tabs)/apps/_layout.tsx`) [[1]](diffhunk://#diff-8eb913684b483f84d0b865d434486444c108bf14c04b5f75ba16c40c0336b590L97-R99) [[2]](diffhunk://#diff-8eb913684b483f84d0b865d434486444c108bf14c04b5f75ba16c40c0336b590L109-R112)

- Minor code update:
  * Added `Pressable` to the imports, although it is not yet used in the component. (`frontend/app/(tabs)/apps/_layout.tsx`)