### PR TITLE
fix: stop persistent alarm permission prompt on relaunch

### DIFF
--- a/frontend/constants/Constants.ts
+++ b/frontend/constants/Constants.ts
@@ -90,6 +90,7 @@ export const NEWS_URL = process.env.EXPO_PUBLIC_NEWS_URL ?? "";
 export const NEWS_STORAGE_KEY = "cached_news_feed";
 export const NEWS_TIMESTAMP_KEY = "cached_news_timestamp";
 export const APP_UPDATE_CHECK_TIMESTAMP_KEY = "app_update_check_timestamp";
+export const ALARM_PERMISSION_PROMPTED_KEY = "alarm_permission_prompted";
 export const FULL_SCREEN_VIEWING_MODE = "fullscreen";
 export const DEFAULT_VIEWING_MODE = "default";
 

--- a/frontend/utils/push-notification.ts
+++ b/frontend/utils/push-notification.ts
@@ -14,12 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 import {
+  ALARM_PERMISSION_PROMPTED_KEY,
   ANDROID_NOTIFICATION_SMALL_ICON_ACCENT_COLOR,
   isAndroid,
   isIos,
   NOTIFICATION_CHANNEL_ID,
   NOTIFICATION_CHANNEL_NAME,
 } from "@/constants/Constants";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import notifee, {
   AndroidImportance,
   AndroidNotificationSetting,
@@ -76,7 +78,13 @@ const requestNotificationPermissionAndroid = async (): Promise<boolean> => {
 
   const settings = await notifee.getNotificationSettings();
   if (settings.android.alarm === AndroidNotificationSetting.DISABLED) {
-    await notifee.openAlarmPermissionSettings();
+    const alreadyPrompted = await AsyncStorage.getItem(
+      ALARM_PERMISSION_PROMPTED_KEY
+    );
+    if (!alreadyPrompted) {
+      await AsyncStorage.setItem(ALARM_PERMISSION_PROMPTED_KEY, "1");
+      await notifee.openAlarmPermissionSettings();
+    }
   }
 
   return isGranted;


### PR DESCRIPTION
The app was re-prompting for Alarm & Reminder permissions on every launch when the user denied or ignored the permission. This happened because requestNotificationPermissionAndroid() unconditionally opened the alarm permission settings whenever the alarm setting was disabled.

Fix: Use an AsyncStorage flag (ALARM_PERMISSION_PROMPTED_KEY) to track whether the user has already been shown the alarm permission settings. The prompt is now shown only once. If the user denies or ignores the permission, their choice is respected on subsequent launches.

Closes opensuperapp/opensuperapp#19

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter âN/Aâ plus brief explanation of why thereâs no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type âSentâ when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type âN/Aâ and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android alarm permission prompt now displays only once instead of repeatedly, preventing duplicate prompts and improving user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->