### PR TITLE
[AI Agent] Check Authorization header instead of x-jwt-assertion

### DIFF
--- a/chat-agent/app/main.py
+++ b/chat-agent/app/main.py
@@ -66,18 +66,26 @@ async def health():
 @app.post("/chat", response_model=ChatResponse)
 async def chat(
     request: ChatRequest,
-    x_jwt_assertion: Optional[str] = Header(None, alias="x-jwt-assertion"),
+    authorization: Optional[str] = Header(None, description="Bearer <access_token>"),
 ):
     """
     Process a chat message from the user.
 
-    The x-jwt-assertion header must contain the user's access token.
-    This is populated automatically by Choreo when 'Pass End User Attributes' is enabled.
-    """
-    if not x_jwt_assertion:
-        raise HTTPException(status_code=401, detail="x-jwt-assertion header is required")
+    The Authorization header must contain the user's access token as:
+        Bearer <access_token>
 
-    access_token = x_jwt_assertion
+    The access token is forwarded to micro-app backends for authentication.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header must be in format: Bearer <token>",
+        )
+
+    access_token = authorization[len("Bearer "):]
+
+    if not access_token:
+        raise HTTPException(status_code=401, detail="Access token is required")
 
     # Convert history to list of dicts for the agent
     history = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `/chat` endpoint to read access tokens from the standard `Authorization` header with Bearer token format instead of a custom header. The endpoint now validates token presence and format, returning clear error responses for missing or improperly formatted credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->