### PR TITLE
[AI-Agent] Add Procfile to run uvicorn web process

### DIFF
--- a/chat-agent/.env.example
+++ b/chat-agent/.env.example
@@ -26,3 +26,6 @@ GUEST_WIFI_EXTRA_SCOPES=
 
 # Debug Mode (set to true for local development — adds x-jwt-assertion header)
 DEBUG=false
+
+# Server port (default: 8000)
+PORT=8000

--- a/chat-agent/Procfile
+++ b/chat-agent/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/chat-agent/Procfile
+++ b/chat-agent/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}
+web: python main.py

--- a/chat-agent/main.py
+++ b/chat-agent/main.py
@@ -23,6 +23,7 @@ the agent's response.
 """
 
 import logging
+import os
 from typing import List, Optional
 
 import uvicorn
@@ -115,4 +116,5 @@ async def chat(
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000, h11_max_incomplete_event_size=16384)
+    port = int(os.environ.get("PORT", 8000))
+    uvicorn.run(app, host="0.0.0.0", port=port, h11_max_incomplete_event_size=16384)


### PR DESCRIPTION
### Description

Create chat-agent/Procfile to declare a web process for deployment platforms (e.g., Heroku/Dokku). It runs the app with uvicorn (uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}), allowing the runtime to bind to the provided PORT environment variable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added deployment configuration to standardize application startup and enable flexible port management through environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->