### PR TITLE
[Backend] Feature: Add POST `users/fcm-tokens/search` endpoint

### DIFF
--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -150,15 +150,16 @@ public isolated function updateUserConfigs(string uuid, UserConfig userConfig)
 #
 # + uuids - Array of user UUIDs to retrieve tokens for
 # + startIndex - Start index for pagination
+# + itemsPerPage - Items per page
 # + return - FCMTokenResponse with tokens and pagination info, or an error.
-public isolated function getFcmTokens(string[] uuids, int startIndex) returns FcmTokenResponse|error {
+public isolated function getFcmTokens(string[] uuids, int startIndex, int itemsPerPage = 'limit) returns FcmTokenResponse|error {
     FcmTokenCount countRecord = check databaseClient->queryRow(countFcmTokensQuery(uuids));
 
     if startIndex < 0 || startIndex >= countRecord.count {
         return error(string `Invalid start index: ${startIndex}. Total results: ${countRecord.count}`);
     }
 
-    stream<FcmToken, sql:Error?> tokenStream = databaseClient->query(getFcmTokensQuery(uuids, startIndex));
+    stream<FcmToken, sql:Error?> tokenStream = databaseClient->query(getFcmTokensQuery(uuids, startIndex, itemsPerPage));
     string[] tokens = check from FcmToken tokenRecord in tokenStream
         where tokenRecord.fcmToken != ""
         select tokenRecord.fcmToken;
@@ -167,7 +168,7 @@ public isolated function getFcmTokens(string[] uuids, int startIndex) returns Fc
         fcmTokens: tokens,
         totalResults: countRecord.count,
         startIndex,
-        itemsPerPage: countRecord.count > 'limit ? 'limit : countRecord.count
+        itemsPerPage: countRecord.count > itemsPerPage ? itemsPerPage : countRecord.count
     };
 }
 

--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -152,7 +152,8 @@ public isolated function updateUserConfigs(string uuid, UserConfig userConfig)
 # + startIndex - Start index for pagination
 # + itemsPerPage - Items per page
 # + return - FCMTokenResponse with tokens and pagination info, or an error.
-public isolated function getFcmTokens(string[] uuids, int startIndex, int itemsPerPage = 'limit) returns FcmTokenResponse|error {
+public isolated function getFcmTokens(string[] uuids, int startIndex, int itemsPerPage = 'limit) 
+    returns FcmTokenResponse|error {
     FcmTokenCount countRecord = check databaseClient->queryRow(countFcmTokensQuery(uuids));
 
     if startIndex < 0 || startIndex >= countRecord.count {

--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -155,6 +155,14 @@ public isolated function updateUserConfigs(string uuid, UserConfig userConfig)
 public isolated function getFcmTokens(string[] uuids, int startIndex, int itemsPerPage = 'limit) 
     returns FcmTokenResponse|error {
     FcmTokenCount countRecord = check databaseClient->queryRow(countFcmTokensQuery(uuids));
+    if countRecord.count == 0 {
+        return {
+            fcmTokens: [],
+            totalResults: 0,
+            startIndex,
+            itemsPerPage: 0
+        };
+    }
 
     if startIndex < 0 || startIndex >= countRecord.count {
         return error(string `Invalid start index: ${startIndex}. Total results: ${countRecord.count}`);

--- a/backend/modules/database/db_queries.bal
+++ b/backend/modules/database/db_queries.bal
@@ -170,7 +170,8 @@ isolated function updateUserConfigsQuery(string uuid, string configKey, string c
 # + startIndex - Start index for pagination
 # + itemsPerPage - Items per page
 # + return - Generated query to get FCM tokens from the `device_token` table
-public isolated function getFcmTokensQuery(string[] uuids, int startIndex, int itemsPerPage = 'limit) returns sql:ParameterizedQuery =>
+public isolated function getFcmTokensQuery(string[] uuids, int startIndex, int itemsPerPage = 'limit)
+    returns sql:ParameterizedQuery =>
     sql:queryConcat(`
         SELECT
             t.fcm_token

--- a/backend/modules/database/db_queries.bal
+++ b/backend/modules/database/db_queries.bal
@@ -168,8 +168,9 @@ isolated function updateUserConfigsQuery(string uuid, string configKey, string c
 #
 # + uuids - Array of user UUIDs to retrieve tokens for
 # + startIndex - Start index for pagination
+# + itemsPerPage - Items per page
 # + return - Generated query to get FCM tokens from the `device_token` table
-public isolated function getFcmTokensQuery(string[] uuids, int startIndex) returns sql:ParameterizedQuery =>
+public isolated function getFcmTokensQuery(string[] uuids, int startIndex, int itemsPerPage = 'limit) returns sql:ParameterizedQuery =>
     sql:queryConcat(`
         SELECT
             t.fcm_token
@@ -178,7 +179,7 @@ public isolated function getFcmTokensQuery(string[] uuids, int startIndex) retur
         INNER JOIN
             user_config uc ON t.user_id = uc.id
         WHERE
-            uc.uuid IN (`, sql:arrayFlattenQuery(uuids), `) LIMIT ${'limit} OFFSET ${startIndex}
+            uc.uuid IN (`, sql:arrayFlattenQuery(uuids), `) LIMIT ${itemsPerPage} OFFSET ${startIndex}
     `);
 
 # Query to count FCM tokens for a given list of UUIDs.

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -220,8 +220,8 @@ public type NotificationResponse record {|
 
 # Request type for FCM token search queries.
 public type FcmTokenRequest record {|
-    # Array of user UUIDs
-    string[] userIds;
+    # Array of user emails
+    string[] emails;
     # Required: Pagination offset
     int startIndex;
 |};

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -220,7 +220,7 @@ public type NotificationResponse record {|
 
 # Request type for FCM token search queries.
 public type FcmTokenRequest record {|
-    # Optional: Array of user UUIDs
+    # Array of user UUIDs
     string[] userIds;
     # Required: Pagination offset
     int startIndex;

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -221,7 +221,7 @@ public type NotificationResponse record {|
 # Request type for FCM token search queries.
 public type FcmTokenRequest record {|
     # Optional: Array of user UUIDs
-    string[] userIds?;
+    string[] userIds;
     # Required: Pagination offset
     int startIndex;
 |};

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -223,5 +223,7 @@ public type FcmTokenRequest record {|
     # Array of user emails
     string[] emails;
     # Start index of the response
-    int startIndex;
+    int startIndex = 1;
+    # Limit of items to return
+    int itemsPerPage = 'limit;
 |};

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -217,3 +217,11 @@ public type NotificationResponse record {|
     # Items per page
     int itemsPerPage;
 |};
+
+# Request type for FCM token search queries.
+public type FcmTokenRequest record {|
+    # Optional: Array of user UUIDs
+    string[] userIds?;
+    # Required: Pagination offset
+    int startIndex;
+|};

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -222,6 +222,6 @@ public type NotificationResponse record {|
 public type FcmTokenRequest record {|
     # Array of user emails
     string[] emails;
-    # Required: Pagination offset
+    # Start index of the response
     int startIndex;
 |};

--- a/backend/modules/scim/client.bal
+++ b/backend/modules/scim/client.bal
@@ -17,7 +17,6 @@ import ballerina/http;
 
 configurable string scimUrl = ?;
 configurable Oauth2Config oauth2Config = ?;
-configurable string internalUserDomain = "wso2";
 
 public final http:Client scimClient = check new (scimUrl, {
     auth: {

--- a/backend/modules/scim/client.bal
+++ b/backend/modules/scim/client.bal
@@ -17,6 +17,7 @@ import ballerina/http;
 
 configurable string scimUrl = ?;
 configurable Oauth2Config oauth2Config = ?;
+configurable string internalUserDomain = ?;
 
 public final http:Client scimClient = check new (scimUrl, {
     auth: {

--- a/backend/modules/scim/client.bal
+++ b/backend/modules/scim/client.bal
@@ -17,7 +17,7 @@ import ballerina/http;
 
 configurable string scimUrl = ?;
 configurable Oauth2Config oauth2Config = ?;
-configurable string internalUserDomain = ?;
+configurable string internalUserDomain = "wso2";
 
 public final http:Client scimClient = check new (scimUrl, {
     auth: {

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -37,3 +37,38 @@ public isolated function searchUsers(string group) returns User[]|error {
     }
     return users;
 }
+
+# Searches for Internal users by email from the SCIM operations service.
+#
+# + email - Email of the user to search for
+# + return - An array of User records, or an error if the operation fails
+public isolated function getInternalUserIdByEmail(string email) returns User[]|error {
+    User[] users = [];
+
+    UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
+        domain: "DEFAULT",
+        attributes: ["userName", "id"],
+        filter: string `userName eq ${email}`
+    });
+
+    users.push(...usersResult.Resources);
+    return users;
+}
+
+# Searches for External users by email from the SCIM operations service.
+#
+# + email - Email of the user to search for
+# + return - An array of User records, or an error if the operation fails
+public isolated function getExternalUserIdByEmail(string email) returns User[]|error {
+
+    User[] users = [];
+
+    UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
+        domain: "DEFAULT",
+        attributes: ["userName", "id"],
+        filter: string `userName eq ${email}`
+    });
+
+    users.push(...usersResult.Resources);
+    return users;
+}

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -44,7 +44,6 @@ public isolated function searchUsers(string group) returns User[]|error {
 # + return - An array of User records, or an error if the operation fails
 public isolated function getInternalUserIdByEmail(string email) returns User[]|error {
     User[] users = [];
-
     UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],
@@ -60,9 +59,7 @@ public isolated function getInternalUserIdByEmail(string email) returns User[]|e
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
 public isolated function getExternalUserIdByEmail(string email) returns User[]|error {
-
     User[] users = [];
-
     UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -42,7 +42,7 @@ public isolated function searchUsers(string group) returns User[]|error {
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function getInternalUserIdByEmail(string email) returns User[]|error {
+public isolated function getInternalUserByEmail(string email) returns User[]|error {
     User[] users = [];
     UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
         domain: "DEFAULT",
@@ -58,7 +58,7 @@ public isolated function getInternalUserIdByEmail(string email) returns User[]|e
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function getExternalUserIdByEmail(string email) returns User[]|error {
+public isolated function getExternalUserByEmail(string email) returns User[]|error {
     User[] users = [];
     UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
         domain: "DEFAULT",

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -42,30 +42,34 @@ public isolated function searchUsers(string group) returns User[]|error {
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function getInternalUserByEmail(string email) returns User[]|error {
-    User[] users = [];
+public isolated function searchInternalUsers(string email) returns User?|error {
     UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],
         filter: string `userName eq ${email}`
     });
 
-    users.push(...usersResult.Resources);
-    return users;
+    if usersResult.Resources.length() >= 1 {
+        return usersResult.Resources[0];
+    }
+
+    return ();
 }
 
 # Searches for External users by email from the SCIM operations service.
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function getExternalUserByEmail(string email) returns User[]|error {
-    User[] users = [];
+public isolated function searchExternalUsers(string email) returns User?|error {
     UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],
         filter: string `userName eq ${email}`
     });
 
-    users.push(...usersResult.Resources);
-    return users;
+    if usersResult.Resources.length() >= 1 {
+        return usersResult.Resources[0];
+    }
+
+    return ();
 }

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -41,7 +41,7 @@ public isolated function searchUsers(string group) returns User[]|error {
 # Searches for Internal users by email from the SCIM operations service.
 #
 # + email - Email of the user to search for
-# + return - An array of User records, or an error if the operation fails
+# + return - A User record or nil, or an error if the operation fails
 public isolated function searchInternalUsers(string email) returns User|error? {
     UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
         domain: "DEFAULT",
@@ -59,7 +59,7 @@ public isolated function searchInternalUsers(string email) returns User|error? {
 # Searches for External users by email from the SCIM operations service.
 #
 # + email - Email of the user to search for
-# + return - An array of User records, or an error if the operation fails
+# + return - A User record or nil, or an error if the operation fails
 public isolated function searchExternalUsers(string email) returns User|error? {
     UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
         domain: "DEFAULT",

--- a/backend/modules/scim/scim.bal
+++ b/backend/modules/scim/scim.bal
@@ -42,7 +42,7 @@ public isolated function searchUsers(string group) returns User[]|error {
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function searchInternalUsers(string email) returns User?|error {
+public isolated function searchInternalUsers(string email) returns User|error? {
     UserSearchResult usersResult = check scimClient->/organizations/internal/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],
@@ -60,7 +60,7 @@ public isolated function searchInternalUsers(string email) returns User?|error {
 #
 # + email - Email of the user to search for
 # + return - An array of User records, or an error if the operation fails
-public isolated function searchExternalUsers(string email) returns User?|error {
+public isolated function searchExternalUsers(string email) returns User|error? {
     UserSearchResult usersResult = check scimClient->/organizations/'external/users/search.post({
         domain: "DEFAULT",
         attributes: ["userName", "id"],

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -13,7 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import ballerina/log;
+configurable string internalUserDomain = "wso2";
 
 # Gets the user ids of users belonging to a specific group from the SCIM operations service.
 #
@@ -54,7 +54,6 @@ public isolated function isInternalUser(string email) returns boolean =>
 # + email - Email of the user to search for
 # + return - The user id of the user, or an error if the operation fails
 isolated function getUserIdByDomain(string email) returns string?|error {
-    log:printInfo(string `isInternalUser(email): ${isInternalUser(email)}`);
     User? user = isInternalUser(email) ? check searchInternalUsers(email) : check searchExternalUsers(email);
     if user is () {
         return ();

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -46,7 +46,12 @@ public isolated function getUserIdsByEmails(string[] emails) returns string[]|er
 # + email - Email of the user to check
 # + return - `true` if the user is an internal user, `false` otherwise
 public isolated function isInternalUser(string email) returns boolean {
-    return email.includes(internalUserDomain);
+    int? atIndex = email.lastIndexOf("@");
+    if atIndex is () {
+        return false;
+    }
+    string domain = email.substring(atIndex + 1);
+    return domain.equalsIgnoreCaseAscii(internalUserDomain);
 }
 
 # Gets the user id of a user by their email from the SCIM operations service.

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -12,7 +12,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
-// under the License. 
+// under the License.
+import ballerina/log;
 
 # Gets the user ids of users belonging to a specific group from the SCIM operations service.
 #
@@ -45,23 +46,18 @@ public isolated function getUserIdsByEmails(string[] emails) returns string[]|er
 #
 # + email - Email of the user to check
 # + return - `true` if the user is an internal user, `false` otherwise
-public isolated function isInternalUser(string email) returns boolean {
-    int? atIndex = email.lastIndexOf("@");
-    if atIndex is () {
-        return false;
-    }
-    string domain = email.substring(atIndex + 1);
-    return domain.equalsIgnoreCaseAscii(internalUserDomain);
-}
+public isolated function isInternalUser(string email) returns boolean =>
+    re `^[a-zA-Z][a-zA-Z0-9_\-\.]+@${internalUserDomain}\.com$`.isFullMatch(email.toLowerAscii());
 
 # Gets the user id of a user by their email from the SCIM operations service.
 #
 # + email - Email of the user to search for
 # + return - The user id of the user, or an error if the operation fails
 isolated function getUserIdByDomain(string email) returns string?|error {
-    User[] users = isInternalUser(email) ? check getInternalUserByEmail(email) : check getExternalUserByEmail(email);
-    if users.length() == 0 {
+    log:printInfo(string `isInternalUser(email): ${isInternalUser(email)}`);
+    User? user = isInternalUser(email) ? check searchInternalUsers(email) : check searchExternalUsers(email);
+    if user is () {
         return ();
     }
-    return users[0].id;
+    return user.id;
 }

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -55,8 +55,5 @@ public isolated function isInternalUser(string email) returns boolean =>
 # + return - The user id of the user, or an error if the operation fails
 isolated function getUserIdByDomain(string email) returns string?|error {
     User? user = isInternalUser(email) ? check searchInternalUsers(email) : check searchExternalUsers(email);
-    if user is () {
-        return ();
-    }
-    return user.id;
+    return user is () ? () : user.id;
 }

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -59,7 +59,7 @@ public isolated function isInternalUser(string email) returns boolean {
 # + email - Email of the user to search for
 # + return - The user id of the user, or an error if the operation fails
 isolated function getUserIdByDomain(string email) returns string?|error {
-    User[] users = isInternalUser(email) ? check getInternalUserIdByEmail(email) : check getExternalUserIdByEmail(email);
+    User[] users = isInternalUser(email) ? check getInternalUserByEmail(email) : check getExternalUserByEmail(email);
     if users.length() == 0 {
         return ();
     }

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -23,3 +23,40 @@ public isolated function getGroupMemberIds(string group) returns string[]|error 
     return from User user in users
         select user.id;
 }
+
+# Gets the user ids of users by their emails from the SCIM operations service.
+#
+# + emails - Array of emails of the users to search for
+# + return - An array of user ids, or an error if the operation fails
+public isolated function getUserIdsByEmails(string[] emails) returns string[]|error {
+    string[] userIds = [];
+    foreach string email in emails {
+        string? userId = check getUserIdByDomain(email);
+        if userId is () {
+            continue;
+        }
+        userIds.push(userId);
+    }
+
+    return userIds;
+}
+
+# Checks if a user is an internal user.
+#
+# + email - Email of the user to check
+# + return - `true` if the user is an internal user, `false` otherwise
+public isolated function isInternalUser(string email) returns boolean {
+    return email.includes(internalUserDomain);
+}
+
+# Gets the user id of a user by their email from the SCIM operations service.
+#
+# + email - Email of the user to search for
+# + return - The user id of the user, or an error if the operation fails
+isolated function getUserIdByDomain(string email) returns string?|error {
+    User[] users = isInternalUser(email) ? check getInternalUserIdByEmail(email) : check getExternalUserIdByEmail(email);
+    if users.length() == 0 {
+        return ();
+    }
+    return users[0].id;
+}

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -49,7 +49,7 @@ service class ErrorInterceptor {
     }
 }
 
-service http:InterceptableService / on new http:Listener(9090, config = {requestLimits: {maxHeaderSize}}) {
+service http:InterceptableService / on new http:Listener(9099, config = {requestLimits: {maxHeaderSize}}) {
 
     # + return - authorization:JwtInterceptor, ErrorInterceptor
     public function createInterceptors() returns http:Interceptor[] =>
@@ -409,7 +409,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
     # + request - Request containing userIds and startIndex
     # + return - Paginated FCM tokens response or an error
     resource function post users/fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
-        returns database:FcmTokenResponse|http:InternalServerError|http:BadRequest|http:Ok {
+        returns http:InternalServerError|http:BadRequest|http:Ok {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -434,7 +434,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
+        database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex, request.itemsPerPage);
         if fcmTokensResponse is error {
             string customError = "Error occurred while retrieving FCM tokens";
             return <http:InternalServerError> {

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -429,13 +429,13 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
 
             database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
             if fcmTokensResponse is error {
-                string customError = "Error occurred while retrieving FCM tokens";
-                log:printError(customError, fcmTokensResponse);
-                return <http:InternalServerError>{
-                    body: {info: customError, message: fcmTokensResponse.message()}
+                return {
+                    fcmTokens: [],
+                    totalResults: 0,
+                    startIndex: request.startIndex,
+                    itemsPerPage: 0
                 };
             }
-            
             return fcmTokensResponse;
         } else {
             return <http:BadRequest>{

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -409,7 +409,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
     # + request - Request containing userIds and startIndex
     # + return - Paginated FCM tokens response or an error
     resource function post users/fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
-        returns database:FcmTokenResponse|http:InternalServerError|http:NotFound|http:BadRequest {
+        returns database:FcmTokenResponse|http:InternalServerError|http:BadRequest {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -418,30 +418,33 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        string[]? userIds = request.userIds;
-
-        if userIds is string[] {
-            if userIds.length() == 0 {
-                return <http:BadRequest>{
-                    body: {message: "userIds array cannot be empty"}
-                };
-            }
-
-            database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
-            if fcmTokensResponse is error {
-                return {
-                    fcmTokens: [],
-                    totalResults: 0,
-                    startIndex: request.startIndex,
-                    itemsPerPage: 0
-                };
-            }
-            return fcmTokensResponse;
-        } else {
+        string[] emails = request.emails;
+        if emails.length() == 0 {
             return <http:BadRequest>{
-                body: {message: "'userIds' must be provided"}
+                body: {message: "emails array cannot be empty"}
             };
         }
+
+        string[]|error userIds = scim:getUserIdsByEmails(emails);
+        if userIds is error {
+            string customError = "Error occurred while calling SCIM operations service";
+            log:printError(customError, userIds);
+            return <http:InternalServerError>{
+                body: {message: customError}
+            };
+        }
+
+        database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
+        if fcmTokensResponse is error {
+            return {
+                fcmTokens: [],
+                totalResults: 0,
+                startIndex: request.startIndex,
+                itemsPerPage: 0
+            };
+        }
+        
+        return fcmTokensResponse;
     }
 
     # Deletes the specified FCM token.

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -49,7 +49,7 @@ service class ErrorInterceptor {
     }
 }
 
-service http:InterceptableService / on new http:Listener(9099, config = {requestLimits: {maxHeaderSize}}) {
+service http:InterceptableService / on new http:Listener(9090, config = {requestLimits: {maxHeaderSize}}) {
 
     # + return - authorization:JwtInterceptor, ErrorInterceptor
     public function createInterceptors() returns http:Interceptor[] =>
@@ -408,7 +408,7 @@ service http:InterceptableService / on new http:Listener(9099, config = {request
     # + ctx - Request context
     # + request - Request containing userIds and startIndex
     # + return - Paginated FCM tokens response or an error
-    resource function post users/fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
+    resource function post fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
         returns http:InternalServerError|http:BadRequest|http:Ok {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
@@ -450,7 +450,8 @@ service http:InterceptableService / on new http:Listener(9099, config = {request
             };
         }
 
-        database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex, request.itemsPerPage);
+        database:FcmTokenResponse|error fcmTokensResponse = 
+            database:getFcmTokens(userIds, request.startIndex, request.itemsPerPage);
         if fcmTokensResponse is error {
             string customError = "Error occurred while retrieving FCM tokens";
             log:printError(customError, fcmTokensResponse);

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -403,6 +403,47 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
         return <http:Ok>{body: {message: result}};
     }
 
+    # Search for FCM tokens using user UUIDs.
+    #
+    # + ctx - Request context
+    # + request - Request containing userIds and startIndex
+    # + return - Paginated FCM tokens response or an error
+    resource function post users/fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
+        returns database:FcmTokenResponse|http:InternalServerError|http:NotFound|http:BadRequest {
+
+        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {message: ERR_MSG_USER_HEADER_NOT_FOUND}
+            };
+        }
+
+        string[]? userIds = request.userIds;
+
+        if userIds is string[] {
+            if userIds.length() == 0 {
+                return <http:BadRequest>{
+                    body: {message: "userIds array cannot be empty"}
+                };
+            }
+
+            database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
+            if fcmTokensResponse is error {
+                string customError = "Error occurred while retrieving FCM tokens";
+                log:printError(customError, fcmTokensResponse);
+                return <http:InternalServerError>{
+                    body: {info: customError, message: fcmTokensResponse.message()}
+                };
+            }
+            
+            return fcmTokensResponse;
+        } else {
+            return <http:BadRequest>{
+                body: {message: "'userIds' must be provided"}
+            };
+        }
+    }
+
     # Deletes the specified FCM token.
     #
     # + ctx - Request context

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -409,7 +409,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
     # + request - Request containing userIds and startIndex
     # + return - Paginated FCM tokens response or an error
     resource function post users/fcm\-tokens/search(http:RequestContext ctx, database:FcmTokenRequest request)
-        returns database:FcmTokenResponse|http:InternalServerError|http:BadRequest {
+        returns database:FcmTokenResponse|http:InternalServerError|http:BadRequest|http:Ok {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -436,15 +436,20 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
 
         database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex);
         if fcmTokensResponse is error {
-            return {
-                fcmTokens: [],
-                totalResults: 0,
-                startIndex: request.startIndex,
-                itemsPerPage: 0
+            string customError = "Error occurred while retrieving FCM tokens";
+            return <http:InternalServerError> {
+                body: {message: customError}
             };
         }
-        
-        return fcmTokensResponse;
+
+        return <http:Ok> {
+            body: {
+                fcmTokens: fcmTokensResponse.fcmTokens,
+                totalResults: fcmTokensResponse.totalResults,
+                startIndex: fcmTokensResponse.startIndex,
+                itemsPerPage: fcmTokensResponse.itemsPerPage
+            }
+        };
     }
 
     # Deletes the specified FCM token.

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -418,6 +418,12 @@ service http:InterceptableService / on new http:Listener(9099, config = {request
             };
         }
 
+        if request.startIndex < 0 || request.itemsPerPage <= 0 {
+            return <http:BadRequest>{
+                body: {message: "'startIndex' must be >= 0 and 'itemsPerPage' must be > 0"}
+            };
+        }
+
         string[] emails = request.emails;
         if emails.length() == 0 {
             return <http:BadRequest>{
@@ -433,10 +439,21 @@ service http:InterceptableService / on new http:Listener(9099, config = {request
                 body: {message: customError}
             };
         }
+        if userIds.length() == 0 {
+            return <http:Ok>{
+                body: {
+                    fcmTokens: [],
+                    totalResults: 0,
+                    startIndex: request.startIndex,
+                    itemsPerPage: 0
+                }
+            };
+        }
 
         database:FcmTokenResponse|error fcmTokensResponse = database:getFcmTokens(userIds, request.startIndex, request.itemsPerPage);
         if fcmTokensResponse is error {
             string customError = "Error occurred while retrieving FCM tokens";
+            log:printError(customError, fcmTokensResponse);
             return <http:InternalServerError> {
                 body: {message: customError}
             };

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -28,6 +28,8 @@ configurable string userRegionFilter = ?; // Region to bypass region restricted 
 configurable string mobileAppReviewerEmail = ?; // App store reviewer email
 configurable MicroAppScope[] appScopes = []; // Additional scopes required for micro-apps
 
+const int MAX_ITEMS_PER_PAGE = 1000;
+
 @display {
     label: "SuperApp Mobile Service",
     id: "wso2-open-operations/superapp-mobile-service"
@@ -418,9 +420,9 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        if request.startIndex < 0 || request.itemsPerPage <= 0 {
+        if request.startIndex < 1 || request.itemsPerPage <= 0 || request.itemsPerPage > MAX_ITEMS_PER_PAGE {
             return <http:BadRequest>{
-                body: {message: "'startIndex' must be >= 0 and 'itemsPerPage' must be > 0"}
+                body: {message: string`'startIndex' must be >= 1 and 'itemsPerPage' must be > 0 and <= ${MAX_ITEMS_PER_PAGE}`}
             };
         }
 
@@ -451,7 +453,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
         }
 
         database:FcmTokenResponse|error fcmTokensResponse = 
-            database:getFcmTokens(userIds, request.startIndex, request.itemsPerPage);
+            database:getFcmTokens(userIds, request.startIndex - 1, request.itemsPerPage);
         if fcmTokensResponse is error {
             string customError = "Error occurred while retrieving FCM tokens";
             log:printError(customError, fcmTokensResponse);


### PR DESCRIPTION
### Description

This PR adds a new POST endpoint `users/fcm-tokens/search` which retrieves the FCM's for an array of user ID's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to search FCM tokens by user email addresses with built-in pagination support
  * Configurable page size allows customization of result set limits for search queries
  * Enhanced user resolution system to identify both internal and external users using email addresses
  * Implemented validation for search inputs including email lists and pagination parameters to ensure data integrity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->