### PR TITLE
[Backend] Update user/notifications endpoint fetch notifications which has targeted users

### DIFF
--- a/backend/Dependencies.toml
+++ b/backend/Dependencies.toml
@@ -21,6 +21,14 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "avro"
+version = "1.2.1"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "cache"
 version = "3.10.0"
 dependencies = [
@@ -44,7 +52,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -105,7 +113,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -331,7 +339,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -390,18 +398,54 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.0.3"
+version = "1.2.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerinai", name = "observe"}
+	{org = "ballerina", name = "log"},
+	{org = "ballerinai", name = "observe"},
+	{org = "ballerinax", name = "kafka"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "confluent.cavroserdes"
+version = "1.0.3"
+dependencies = [
+	{org = "ballerina", name = "avro"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerinai", name = "observe"},
+	{org = "ballerinax", name = "confluent.cregistry"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "confluent.cregistry"
+version = "0.4.4"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "kafka"
+version = "4.6.5"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"},
+	{org = "ballerinai", name = "observe"},
+	{org = "ballerinax", name = "confluent.cavroserdes"},
+	{org = "ballerinax", name = "confluent.cregistry"}
 ]
 
 [[package]]
 org = "ballerinax"
 name = "mysql"
-version = "1.16.1"
+version = "1.16.4"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "io"},
@@ -418,7 +462,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.driver"
-version = "1.8.0"
+version = "1.8.1"
 modules = [
 	{org = "ballerinax", packageName = "mysql.driver", moduleName = "mysql.driver"}
 ]

--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -240,16 +240,17 @@ public isolated function addDefaultUserConfig(string uuid, string[] configValues
     };
 }
 
-# Get notifications filtered by user groups.
+# Get notifications filtered by user groups and user ID.
 #
 # + groups - Array of user groups
+# + userId - User UUID to match against target_users
 # + startIndex - Start index for pagination
 # + itemsPerPage - Items per page
 # + return - Array of Notification or error
-public isolated function getNotifications(string[] groups, int startIndex, int itemsPerPage)
+public isolated function getNotifications(string[] groups, string userId, int startIndex, int itemsPerPage)
     returns NotificationResponse|error? {
 
-    NotificationsCount countRecord = check databaseClient->queryRow(getNotificationsCountQuery(groups));
+    NotificationsCount countRecord = check databaseClient->queryRow(getNotificationsCountQuery(groups, userId));
 
     if startIndex < 0 || startIndex >= countRecord.count {
         log:printDebug("Invalid start index", startIndex = startIndex, totalResults = countRecord.count);
@@ -257,7 +258,7 @@ public isolated function getNotifications(string[] groups, int startIndex, int i
     }
 
     stream<DbNotification, sql:Error?> result =
-        databaseClient->query(getNotificationsQuery(groups, startIndex, itemsPerPage));
+        databaseClient->query(getNotificationsQuery(groups, userId, startIndex, itemsPerPage));
 
     Notification[] notifications = check from DbNotification notification in result
         select {

--- a/backend/modules/database/db_queries.bal
+++ b/backend/modules/database/db_queries.bal
@@ -237,44 +237,74 @@ public isolated function getAppConfigsQuery() returns sql:ParameterizedQuery => 
         app_configs
 `;
 
-# Query to get the count of notifications filtered by user groups.
+# Query to get the count of notifications filtered by user groups and user ID.
 #
 # + groups - Array of user groups to match against target_roles
+# + userId - User UUID to match against target_users
 # + return - Generated query to count filtered notifications
-public isolated function getNotificationsCountQuery(string[] groups) returns sql:ParameterizedQuery {
-    sql:ParameterizedQuery filterQuery = generateTargetRolesFilters(groups);
+public isolated function getNotificationsCountQuery(string[] groups, string userId) returns sql:ParameterizedQuery {
+    sql:ParameterizedQuery usersFilter = generateTargetUsersFilter(userId);
+    if groups.length() == 0 {
+        return sql:queryConcat(`
+            SELECT
+                COUNT(*) as count
+            FROM
+                push_notification
+            WHERE
+                (`, usersFilter, `)
+        `);
+    }
+    sql:ParameterizedQuery rolesFilter = generateTargetRolesFilters(groups);
     return sql:queryConcat(`
-        SELECT 
+        SELECT
             COUNT(*) as count
-        FROM 
+        FROM
             push_notification
-        WHERE 
-            (`, filterQuery, `)
+        WHERE
+            (`, rolesFilter, ` OR `, usersFilter, `)
     `);
 }
 
-# Query to get notifications filtered by user groups.
+# Query to get notifications filtered by user groups and user ID.
 #
 # + groups - Array of user groups to match against target_roles
+# + userId - User UUID to match against target_users
 # + startIndex - Start index for pagination
 # + itemsPerPage - Items per page
 # + return - Generated query to retrieve filtered notifications
-public isolated function getNotificationsQuery(string[] groups, int startIndex, int itemsPerPage)
+public isolated function getNotificationsQuery(string[] groups, string userId, int startIndex, int itemsPerPage)
     returns sql:ParameterizedQuery {
 
-    sql:ParameterizedQuery filterQuery = generateTargetRolesFilters(groups);
+    sql:ParameterizedQuery usersFilter = generateTargetUsersFilter(userId);
+    if groups.length() == 0 {
+        return sql:queryConcat(`
+            SELECT DISTINCT
+                id,
+                title,
+                message,
+                created_by,
+                created_at
+            FROM
+                push_notification
+            WHERE
+                (`, usersFilter, `)
+            ORDER BY
+                created_at DESC
+            LIMIT ${itemsPerPage} OFFSET ${startIndex}
+        `);
+    }
+    sql:ParameterizedQuery rolesFilter = generateTargetRolesFilters(groups);
     return sql:queryConcat(`
-        SELECT 
+        SELECT DISTINCT
             id,
             title,
             message,
-            target_roles,
             created_by,
             created_at
-        FROM 
+        FROM
             push_notification
-        WHERE 
-            (`, filterQuery, `)
+        WHERE
+            (`, rolesFilter, ` OR `, usersFilter, `)
         ORDER BY
             created_at DESC
         LIMIT ${itemsPerPage} OFFSET ${startIndex}

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -183,9 +183,6 @@ public type DbNotification record {|
     string title;
     # Message body
     string message;
-    # Target roles (groups)
-    @sql:Column {name: "target_roles"}
-    string targetRoles;
     # Creator of the notification
     @sql:Column {name: "created_by"}
     string createdBy;

--- a/backend/modules/database/utils.bal
+++ b/backend/modules/database/utils.bal
@@ -40,3 +40,11 @@ isolated function generateTargetRolesFilters(string[] groups) returns sql:Parame
     }
     return filterQuery;
 }
+
+# Generates filter for target users.
+#
+# + userId - User UUID to match against target_users
+# + return - Generated filter query
+isolated function generateTargetUsersFilter(string userId) returns sql:ParameterizedQuery {
+    return `FIND_IN_SET(${userId}, target_users) > 0`;
+}

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -519,18 +519,10 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        string[]? groups = userInfo.groups;
-        if groups is () {
-            return {
-                notifications: [],
-                totalResults: 0,
-                startIndex: 0,
-                itemsPerPage: 0
-            };
-        }
+        string[] groups = userInfo.groups ?: [];
 
         database:NotificationResponse|error? notifications =
-            database:getNotifications(groups, startIndex, itemsPerPage);
+            database:getNotifications(groups, userInfo.userId, startIndex, itemsPerPage);
 
         if notifications is () {
             return {


### PR DESCRIPTION
### Summary  
Updated the `GET /user/notifications` endpoint to fetch notifications based on a newly introduced `target_users` column.

### Changes  
- Added a new column `target_users` to the `push_notification` table  
- `target_users` stores user UUIDs in a comma-separated format  
- Enhanced `user/notifications` endpoint to filter and return notifications relevant to the logged-in user based on `target_users` and `target_roles`.

### Behavior  
- If `target_users` contains UUIDs → only users included in the list will view the notification  

#### Testing  
- Verified notifications are returned correctly for:
  - Users included in `target_users`
  - Global notifications (`target_users = NULL`)
- Confirmed no impact on existing notification flows    

### Related Issues
- https://github.com/wso2-enterprise/wso2-digital-team-project-management/issues/8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification system with user-scoped filtering capabilities in addition to existing group-based filtering.

* **Dependencies**
  * Updated core packages including crypto, HTTP, and time libraries.
  * Added new integrations for Avro serialization and CDC functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->