### PR TITLE
[Frontend] Bugfix: Gate Chat tab on jwt-decoded auth email

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -96,7 +96,11 @@ const tabs: TabType[] = [
 export default function TabLayout() {
   useRestoreLastTab();
 
-  const user = useSelector((state: RootState) => state.userInfo.userInfo);
+  const authEmail = useSelector((state: RootState) => state.auth.email);
+  const workEmail = useSelector(
+    (state: RootState) => state.userInfo.userInfo?.workEmail
+  );
+  const email = authEmail ?? workEmail ?? null;
   const authState = useSelector((state: RootState) => state.auth.accessToken);
   const isAuthenticated = Boolean(authState);
 
@@ -118,7 +122,7 @@ export default function TabLayout() {
     >
       {tabs.map((tab, index) => {
         const effectiveRules = loading ? DEFAULT_TAB_CONFIG : rules;
-        const showTab = shouldShowTab(tab.name, user, isAuthenticated, effectiveRules);
+        const showTab = shouldShowTab(tab.name, email, isAuthenticated, effectiveRules);
 
         return (
           <Tabs.Screen

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1646,9 +1646,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6222,6 +6222,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {

--- a/frontend/utils/__tests__/tabVisibility.test.ts
+++ b/frontend/utils/__tests__/tabVisibility.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { shouldShowTab } from "@/utils/tabVisibility";
+import { DEFAULT_TAB_CONFIG } from "@/types/remoteConfig.types";
+
+describe("shouldShowTab — chat (domain_specific, gated to wso2.com)", () => {
+  const rules = DEFAULT_TAB_CONFIG;
+
+  it("shows chat for an authenticated wso2.com email", () => {
+    expect(shouldShowTab("chat", "alice@wso2.com", true, rules)).toBe(true);
+  });
+
+  it("is case-insensitive on the email domain", () => {
+    expect(shouldShowTab("chat", "Alice@WSO2.COM", true, rules)).toBe(true);
+  });
+
+  it("hides chat for an authenticated non-wso2.com email", () => {
+    expect(shouldShowTab("chat", "bob@example.com", true, rules)).toBe(false);
+  });
+
+  it("hides chat (defaultVisible: false) when the email is null but authenticated", () => {
+    expect(shouldShowTab("chat", null, true, rules)).toBe(false);
+  });
+
+  it("hides chat (defaultVisible: false) when the email is undefined but authenticated", () => {
+    expect(shouldShowTab("chat", undefined, true, rules)).toBe(false);
+  });
+
+  it("hides chat for an unauthenticated user even with a wso2.com email", () => {
+    expect(shouldShowTab("chat", "alice@wso2.com", false, rules)).toBe(false);
+  });
+
+  it("hides chat for an unauthenticated guest with no email", () => {
+    expect(shouldShowTab("chat", null, false, rules)).toBe(false);
+  });
+
+  it("falls back to DEFAULT_TAB_CONFIG when no rules are provided", () => {
+    expect(shouldShowTab("chat", "alice@wso2.com", true, null)).toBe(true);
+    expect(shouldShowTab("chat", "bob@example.com", true, undefined)).toBe(false);
+  });
+});
+
+describe("shouldShowTab — public tabs are unaffected by email", () => {
+  it("shows a public tab regardless of email or auth", () => {
+    expect(shouldShowTab("index", null, false, DEFAULT_TAB_CONFIG)).toBe(true);
+    expect(shouldShowTab("profile", "bob@example.com", true, DEFAULT_TAB_CONFIG)).toBe(
+      true
+    );
+  });
+});
+
+describe("shouldShowTab — unknown tab", () => {
+  it("defaults to visible when no rule exists for the tab", () => {
+    expect(shouldShowTab("nonexistent", null, false, DEFAULT_TAB_CONFIG)).toBe(true);
+  });
+});

--- a/frontend/utils/tabVisibility.ts
+++ b/frontend/utils/tabVisibility.ts
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import { BasicUserInfo } from "@/types/basicUserInfo.types";
 import { DEFAULT_TAB_CONFIG, TabVisibilityConfig, TabRule } from "@/types/remoteConfig.types";
 
 const extractDomain = (email: string | undefined): string | null => {
@@ -32,10 +31,10 @@ const extractDomain = (email: string | undefined): string | null => {
 
 const evaluateRule = (
   rule: TabRule,
-  user: BasicUserInfo | null,
+  email: string | null | undefined,
   isAuthenticated: boolean
 ): boolean => {
-  const userDomain = extractDomain(user?.workEmail);
+  const userDomain = extractDomain(email ?? undefined);
 
   switch (rule.mode) {
     case "public":
@@ -79,7 +78,7 @@ const evaluateRule = (
 
 export const shouldShowTab = (
   tabName: string,
-  user: BasicUserInfo | null,
+  email: string | null | undefined,
   isAuthenticated: boolean,
   rules: TabVisibilityConfig | null | undefined
 ): boolean => {
@@ -90,5 +89,5 @@ export const shouldShowTab = (
     return true;
   }
 
-  return evaluateRule(rule, user, isAuthenticated);
+  return evaluateRule(rule, email, isAuthenticated);
 };


### PR DESCRIPTION
## Description

Chat visibility was gated on `userInfo.workEmail`, which is only fetched via `GET  /user-info` (lazily, on the Profile screen) — so after idle/cold-cache launches the tab stayed hidden until that call returned. This switches the gate to `auth.email`, decoded from the id_token at login and restored from SecureStore at launch with no network, so the chat decision is known immediately (offline included); `workEmail` is kept only as a fallback. `shouldShowTab` now takes a resolved email string instead of a `BasicUserInfo`. Adds a unit test suite for `tabVisibility`.

<img width="632" height="427" alt="Screenshot 2026-06-08 at 12 21 08 PM" src="https://github.com/user-attachments/assets/f2a93587-8955-4fd9-bf12-41d683fa976e" />



Closes https://github.com/wso2-enterprise/wso2-digital-team-project-management/issues/289#issue-4610716854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined chat tab visibility logic to require user authentication with email-based criteria.

* **Tests**
  * Added comprehensive test suite validating tab visibility behavior across various authentication and user states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->