### PR TITLE
Refresh expired token when app-state changes from Background to Foreground

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -51,6 +51,7 @@ import { PersistGate } from "redux-persist/integration/react";
 // Component to handle app initialization
 function AppInitializer({ onReady }: { onReady: () => void }) {
   const dispatch = useDispatch<AppDispatch>(); // Ensure correct typing for async actions
+  const [isInitialized, setIsInitialized] = useState(false);
   const handleLogout = async () => {
     await dispatch(performLogout()).unwrap(); // Ensure the logout action is dispatched properly
   };
@@ -63,7 +64,10 @@ function AppInitializer({ onReady }: { onReady: () => void }) {
   /**
    * Refreshes an expired access token when the app returns to the foreground.
    */
-  useRefreshTokenOnForeground({ onLogout: handleLogout });
+  useRefreshTokenOnForeground({
+    enabled: isInitialized,
+    onLogout: handleLogout,
+  });
 
   useEffect(() => {
     const initialize = async () => {
@@ -89,6 +93,7 @@ function AppInitializer({ onReady }: { onReady: () => void }) {
       } catch (error) {
         console.error("Initialization error:", error);
       } finally {
+        setIsInitialized(true);
         onReady();
       }
     };

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -23,6 +23,7 @@ import { getVersions } from "@/context/slices/versionSlice";
 import { AppDispatch, persistor, store } from "@/context/store";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { usePushNotificationHandler } from "@/hooks/usePushNotificationHandler";
+import { useRefreshTokenOnForeground } from "@/hooks/useRefreshTokenOnForeground";
 import { runMigrations } from "@/migrations/migrator";
 import { buildAppsWithTokens } from "@/utils/exchangedTokenRehydrator";
 import { handleFreshInstall } from "@/utils/freshInstall";
@@ -58,6 +59,11 @@ function AppInitializer({ onReady }: { onReady: () => void }) {
    * Handles push notification token lifecycle.
    */
   usePushNotificationHandler({ onLogout: handleLogout });
+
+  /**
+   * Refreshes an expired access token when the app returns to the foreground.
+   */
+  useRefreshTokenOnForeground({ onLogout: handleLogout });
 
   useEffect(() => {
     const initialize = async () => {

--- a/frontend/hooks/useRefreshTokenOnForeground.ts
+++ b/frontend/hooks/useRefreshTokenOnForeground.ts
@@ -15,7 +15,10 @@
 // under the License.
 import { setAuth } from "@/context/slices/authSlice";
 import { AppDispatch } from "@/context/store";
-import { refreshAccessToken } from "@/services/authService";
+import {
+  getAuthSessionGeneration,
+  refreshAccessToken,
+} from "@/services/authService";
 import { loadAuthDataFromSecureStore } from "@/utils/authTokenStore";
 import { useEffect, useRef } from "react";
 import { AppState } from "react-native";
@@ -29,11 +32,15 @@ import dayjs from "dayjs";
  * from failing with an expired token (or triggering a force logout) when the
  * token expires while the app is backgrounded.
  *
+ * @param enabled - When false, the listener is not registered (e.g. until app
+ * initialization has completed).
  * @param onLogout - The logout function to pass to the refresh for handling auth errors.
  */
 export const useRefreshTokenOnForeground = ({
+  enabled,
   onLogout,
 }: {
+  enabled: boolean;
   onLogout: () => Promise<void>;
 }) => {
   const dispatch = useDispatch<AppDispatch>();
@@ -42,6 +49,8 @@ export const useRefreshTokenOnForeground = ({
   onLogoutRef.current = onLogout;
 
   useEffect(() => {
+    if (!enabled) return;
+
     const subscription = AppState.addEventListener("change", (nextAppState) => {
       if (
         appState.current.match(/inactive|background/) &&
@@ -54,8 +63,12 @@ export const useRefreshTokenOnForeground = ({
 
             if (!isAccessTokenExpired(storedData.accessToken)) return;
 
+            const generation = getAuthSessionGeneration();
             const newAuthData = await refreshAccessToken(onLogoutRef.current);
-            if (newAuthData) {
+            if (
+              newAuthData &&
+              getAuthSessionGeneration() === generation
+            ) {
               dispatch(setAuth(newAuthData));
             }
           } catch (error) {
@@ -74,14 +87,16 @@ export const useRefreshTokenOnForeground = ({
     return () => {
       subscription.remove();
     };
-  }, [dispatch]);
+  }, [dispatch, enabled]);
 };
 
 // Helper function to check if the token is expired
 const isAccessTokenExpired = (accessToken: string): boolean => {
   try {
-    const decoded = jwtDecode<{ exp: number }>(accessToken);
-    return dayjs.unix(decoded.exp).isBefore(dayjs());
+    const decoded = jwtDecode<{ exp?: unknown }>(accessToken);
+    const exp = decoded.exp;
+    if (typeof exp !== "number" || !Number.isFinite(exp)) return true;
+    return dayjs.unix(exp).isBefore(dayjs());
   } catch {
     return true; // Assume expired if decoding fails
   }

--- a/frontend/hooks/useRefreshTokenOnForeground.ts
+++ b/frontend/hooks/useRefreshTokenOnForeground.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { setAuth } from "@/context/slices/authSlice";
+import { AppDispatch } from "@/context/store";
+import { refreshAccessToken } from "@/services/authService";
+import { loadAuthDataFromSecureStore } from "@/utils/authTokenStore";
+import { useEffect, useRef } from "react";
+import { AppState } from "react-native";
+import { useDispatch } from "react-redux";
+import { jwtDecode } from "jwt-decode";
+import dayjs from "dayjs";
+
+/**
+ * Proactively refreshes the access token when the app transitions from the
+ * background/inactive state back to the foreground. This prevents requests
+ * from failing with an expired token (or triggering a force logout) when the
+ * token expires while the app is backgrounded.
+ *
+ * @param onLogout - The logout function to pass to the refresh for handling auth errors.
+ */
+export const useRefreshTokenOnForeground = ({
+  onLogout,
+}: {
+  onLogout: () => Promise<void>;
+}) => {
+  const dispatch = useDispatch<AppDispatch>();
+  const appState = useRef(AppState.currentState);
+  const onLogoutRef = useRef(onLogout);
+  onLogoutRef.current = onLogout;
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextAppState) => {
+      if (
+        appState.current.match(/inactive|background/) &&
+        nextAppState === "active"
+      ) {
+        const refreshIfExpired = async () => {
+          try {
+            const storedData = await loadAuthDataFromSecureStore();
+            if (!storedData?.accessToken) return;
+
+            if (!isAccessTokenExpired(storedData.accessToken)) return;
+
+            const newAuthData = await refreshAccessToken(onLogoutRef.current);
+            if (newAuthData) {
+              dispatch(setAuth(newAuthData));
+            }
+          } catch (error) {
+            console.error(
+              "Error refreshing token on app foreground:",
+              error instanceof Error ? error.message : error
+            );
+          }
+        };
+
+        refreshIfExpired();
+      }
+      appState.current = nextAppState;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [dispatch]);
+};
+
+// Helper function to check if the token is expired
+const isAccessTokenExpired = (accessToken: string): boolean => {
+  try {
+    const decoded = jwtDecode<{ exp: number }>(accessToken);
+    return dayjs.unix(decoded.exp).isBefore(dayjs());
+  } catch {
+    return true; // Assume expired if decoding fails
+  }
+};

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -50,6 +50,15 @@ const REQUESTED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 const MILLISECONDS_IN_A_SECOND = 1000;
 const SCOPE = "openid email groups profile";
 let refreshPromise: Promise<AuthData | null> | null = null;
+let authSessionGeneration = 0;
+
+/** Invalidates any in-flight auth flows (e.g. on logout). */
+export const invalidateAuthSession = () => {
+  authSessionGeneration += 1;
+};
+
+/** Returns the current auth session generation for stale-write detection. */
+export const getAuthSessionGeneration = () => authSessionGeneration;
 
 export interface DecodedIdToken {
   email?: string;
@@ -124,6 +133,7 @@ export const refreshAccessToken = async (
 
   refreshPromise = (async () => {
     try {
+      const generation = authSessionGeneration;
       const storedData = await loadAuthDataFromSecureStore();
       if (!storedData) {
         refreshPromise = null;
@@ -180,6 +190,13 @@ export const refreshAccessToken = async (
           expiresAt: exp * MILLISECONDS_IN_A_SECOND,
         };
 
+        if (authSessionGeneration !== generation) {
+          // Session was invalidated (e.g. logout) while the refresh was
+          // in flight. Do not write the stale session back to storage.
+          refreshPromise = null;
+          return null;
+        }
+
         await saveAuthDataToSecureStore(updatedAuthData as SecureAuthData);
 
         refreshPromise = null;
@@ -210,6 +227,7 @@ export const refreshAccessToken = async (
 };
 
 export const logout = async () => {
+  invalidateAuthSession(); // Invalidate any in-flight refresh flows
   try {
     // Retrieve stored authentication data
     const secureData = await loadAuthDataFromSecureStore();


### PR DESCRIPTION
## Purpose
Resolves https://github.com/opensuperapp/opensuperapp/issues/35

The app fails to proactively refresh authentication tokens when a user returns to the app from a background state. If the Access Token expires while the app is backgrounded, the user is often met with a "Force Logout" or failed API requests upon resuming.

## Goals
- Proactively refresh the access token when the app transitions from the background/inactive state to the foreground.
- Keep the Redux auth state in sync with the refreshed tokens so subsequent requests and hooks use the new token.

## Approach
Added a new hook `useRefreshTokenOnForeground` (`frontend/hooks/useRefreshTokenOnForeground.ts`) that:
- Subscribes to `AppState` changes and detects the `background|inactive -> active` transition.
- Loads the stored auth data from SecureStore; if the access token is expired, calls the existing `refreshAccessToken` (which dedupes concurrent refreshes via a module-level promise and already handles logout on refresh failure) and dispatches `setAuth` to update Redux state.

Wired the hook into `AppInitializer` in `frontend/app/_layout.tsx` alongside `usePushNotificationHandler`.

Cold-start token refresh is unaffected (still handled by `restoreAuth`). Micro-app exchanged tokens self-heal lazily via the existing `tokenExchange` logic.

## User stories
- As a user, when my access token expires while the app is in the background, resuming the app no longer results in failed requests or a forced logout.

## Release note
Proactively refresh an expired access token when the app returns to the foreground from the background.

## Documentation
N/A - Internal behavior change; no user-facing documentation impact.

## Training
N/A

## Certification
N/A - No impact on certification exams.

## Marketing
N/A

## Automation tests
- Unit tests: N/A - No unit test framework coverage exists for this area in the repo.
- Static verification: `eslint` (0 warnings) and `tsc --noEmit` (clean).
- Manual test plan:
  1. Sign in with short-lived access tokens.
  2. Background the app and wait past token expiry.
  3. Resume the app to the foreground.
  4. Confirm no "Force Logout" alert and that API requests succeed with the refreshed token.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin and verified report: no (not configured in this repo)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- React Native 0.76.7 / Expo ~52.0.31
- Verified with `eslint` and `tsc --noEmit`

## Learning
Reused the existing `refreshAccessToken` in `frontend/services/authService.ts` and the `AppState` listener pattern already used in `frontend/components/Scanner.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling when the app returns to the foreground.
  * Expired access tokens are automatically refreshed, helping users stay signed in.
  * Invalid or unreadable tokens are handled gracefully, with logout behavior applied when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->