### PR TITLE
[Open Super App]: wipe microapps from UI on logout

### DIFF
--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -58,7 +58,7 @@ export default function HomeScreen() {
   const downloadProgress = useSelector(
     (state: RootState) => state.apps.downloadProgress
   );
-  const { email } = useSelector((state: RootState) => state.auth);
+  const { userId } = useSelector((state: RootState) => state.auth);
   const isForceUpdate = useSelector(
     (state: RootState) =>
       state.appConfig.configs.find(
@@ -115,7 +115,7 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       const checkForUpdates = async () => {
-        if (isCheckingUpdates.current || !email || !isForceUpdate) {
+        if (isCheckingUpdates.current || !userId || !isForceUpdate) {
           return;
         }
 
@@ -159,13 +159,13 @@ export default function HomeScreen() {
       return () => {
         isCheckingUpdates.current = false;
       };
-    }, [dispatch, email, isForceUpdate, updateCheckIntervalMs])
+    }, [dispatch, userId, isForceUpdate, updateCheckIntervalMs])
   );
 
   // Load micro apps and user configurations if they haven't been initialized yet
   useEffect(() => {
     const initializeApp = async () => {
-      if (!email) return; // Prevent loading micro apps into UI when logged out
+      if (!userId) return; // Prevent loading micro apps into UI when logged out
 
       try {
         if (!apps || apps.length === 0) {
@@ -193,7 +193,7 @@ export default function HomeScreen() {
     };
 
     initializeApp();
-  }, [email]);
+  }, [userId]);
 
   // Load saved app order from AsyncStorage on mount
   useEffect(() => {

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -165,6 +165,8 @@ export default function HomeScreen() {
   // Load micro apps and user configurations if they haven't been initialized yet
   useEffect(() => {
     const initializeApp = async () => {
+      if (!email) return; // Prevent loading micro apps into UI when logged out
+
       try {
         if (!apps || apps.length === 0) {
           await loadMicroAppDetails(

--- a/frontend/services/appStoreService.ts
+++ b/frontend/services/appStoreService.ts
@@ -315,7 +315,7 @@ export const loadMicroAppDetails = async (
     const storedApps = await loadStoredApps();
 
     // Abort if the user logged out during the async operation
-    if (!store.getState().auth.email) return;
+    if (!store.getState().auth.userId) return;
 
     // Dispatch stored apps initially
     dispatch(setApps(storedApps));
@@ -347,7 +347,7 @@ export const loadMicroAppDetails = async (
       });
 
       // Abort if the user logged out during the API fetch
-      if (!store.getState().auth.email) return;
+      if (!store.getState().auth.userId) return;
 
       // Update Redux and AsyncStorage
       dispatch(setApps(await buildAppsWithTokens(apps)));

--- a/frontend/services/appStoreService.ts
+++ b/frontend/services/appStoreService.ts
@@ -29,7 +29,7 @@ import {
   updateAppStatus,
   updateDownloadProgress,
 } from "@/context/slices/appSlice";
-import { AppDispatch } from "@/context/store";
+import { AppDispatch, store } from "@/context/store";
 import { buildAppsWithTokens } from "@/utils/exchangedTokenRehydrator";
 import { persistAppsWithoutTokens } from "@/utils/exchangedTokenStore";
 import { apiRequest } from "@/utils/requestHandler";
@@ -314,6 +314,9 @@ export const loadMicroAppDetails = async (
     // Load stored apps from AsyncStorage
     const storedApps = await loadStoredApps();
 
+    // Abort if the user logged out during the async operation
+    if (!store.getState().auth.email) return;
+
     // Dispatch stored apps initially
     dispatch(setApps(storedApps));
 
@@ -342,6 +345,9 @@ export const loadMicroAppDetails = async (
 
         return mergeAppData(latestApp, storedApp);
       });
+
+      // Abort if the user logged out during the API fetch
+      if (!store.getState().auth.email) return;
 
       // Update Redux and AsyncStorage
       dispatch(setApps(await buildAppsWithTokens(apps)));

--- a/frontend/utils/performLogout.ts
+++ b/frontend/utils/performLogout.ts
@@ -15,6 +15,7 @@
 // under the License.
 import { USER_INFO } from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
+import { setApps } from "@/context/slices/appSlice";
 import { resetAll } from "@/context/slices/authSlice";
 import {
   clearDeviceState,
@@ -37,7 +38,8 @@ export const performLogout = createAsyncThunk(
       await logout(); // Call Asgardeo logout
       await clearAuthDataFromSecureStore();
       await persistor.purge(); // Clear redux-persist storage
-      dispatch(resetAll()); // Reset Redux state completely
+      dispatch(resetAll()); // Reset auth Redux state completely
+      dispatch(setApps([])); // Hide all downloaded apps from the UI
       dispatch(clearDeviceState()); // Reset device state
       dispatch(clearLastSentFcmToken()); // Clear last sent FCM token
 


### PR DESCRIPTION
Small fix to not show the microapps after logout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented app and configuration loading when no user is authenticated.
  - Stopped app loading if authentication ends during the loading process.
  - Cleared downloaded apps from the interface during logout, ensuring app data is no longer visible after signing out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->