### PR TITLE
[Frontend] Bugfix: Apps screen stays stale after silent logout

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,6 +5,9 @@ EXPO_PUBLIC_LOGOUT_URL=https://api.asgardeo.io/t/<asgardeo-organization>/oidc/lo
 EXPO_PUBLIC_BACKEND_BASE_URL=<backend-url>         # Backend API Base URL
 EXPO_PUBLIC_CHAT_AGENT_URL=<chat-agent-url>        # Chat agent API base URL (e.g. http://localhost:8000)
 
+# Optional. JWT "groups" claim value that unlocks dev-only features
+EXPO_PUBLIC_SUPER_APP_DEVELOPER_GROUP=<developer-group-name>
+
 # Please note that this URL is required only for the WSO2 Super App.
 EXPO_PUBLIC_LIBRARY_ARTICLE_FALLBACK_IMAGE=<fallback-image-url>
 

--- a/frontend/app/(tabs)/apps/__tests__/index.test.tsx
+++ b/frontend/app/(tabs)/apps/__tests__/index.test.tsx
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);
+jest.mock("@/services/appStoreService", () => ({
+  loadMicroAppDetails: jest.fn(),
+  downloadMicroApp: jest.fn(),
+  removeMicroApp: jest.fn(),
+}));
+jest.mock("@/services/authService", () => ({
+  logout: jest.fn(),
+}));
+jest.mock("@/context/slices/userConfigSlice", () => ({
+  getUserConfigurations: (onLogout: unknown) => ({
+    type: "userConfig/mock",
+    payload: onLogout,
+  }),
+}));
+jest.mock("@react-navigation/bottom-tabs", () => ({
+  ...jest.requireActual("@react-navigation/bottom-tabs"),
+  useBottomTabBarHeight: () => 0,
+}));
+jest.mock("@/hooks/useTrackActiveScreen", () => ({
+  useTrackActiveScreen: jest.fn(),
+}));
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useFocusEffect: jest.fn(),
+}));
+jest.mock("@/hooks/useSignInWithAsgardeo", () => ({
+  useSignInWithAsgardeo: () => jest.fn(),
+}));
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+// react-redux's package.json "react-native" export condition points at an
+// ESM build this project's Jest transform can't parse; the "default"
+// (alternate-renderers) condition resolves to the same API via CommonJS.
+jest.mock("react-redux", () => require("react-redux/alternate-renderers"));
+
+import SignInMessage from "@/components/SignInMessage";
+import React from "react";
+import { FlatList } from "react-native";
+import { Provider } from "react-redux";
+import { createStore } from "redux";
+import { act, create, ReactTestRenderer } from "react-test-renderer";
+import HomeScreen from "../index";
+
+const baseState = {
+  apps: { apps: [], downloading: [], downloadProgress: {} },
+  auth: {
+    accessToken: null as string | null,
+    refreshToken: null,
+    idToken: null,
+    email: null,
+    userId: null,
+    isLoading: false,
+  },
+  appConfig: {
+    configs: [],
+    defaultMicroAppIds: [],
+    appScopes: [],
+    loading: false,
+    error: null,
+  },
+  version: { versions: [], loading: false, error: null },
+  userConfig: { configurations: [], loading: false },
+};
+
+const buildStore = (accessToken: string | null) =>
+  createStore(() => ({
+    ...baseState,
+    auth: { ...baseState.auth, accessToken },
+  }));
+
+const renderHomeScreen = async (accessToken: string | null) => {
+  const store = buildStore(accessToken);
+  let renderer: ReactTestRenderer;
+
+  jest.useFakeTimers();
+  await act(async () => {
+    renderer = create(
+      <Provider store={store}>
+        <HomeScreen />
+      </Provider>
+    );
+  });
+  // FlatList/VirtualizedList schedules a delayed cell-render update via
+  // setTimeout on mount; flush it now so it doesn't fire after the test ends.
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  jest.useRealTimers();
+
+  return renderer!;
+};
+
+// React.memo() without a custom comparator collapses to a SimpleMemoComponent
+// fiber whose reported `type` is the inner render function, not the memo
+// wrapper object, so findAllByType needs the unwrapped function to match.
+const signInMessageType = (SignInMessage as unknown as { type: unknown }).type;
+
+describe("HomeScreen auth gate", () => {
+  it("shows SignInMessage and no app grid when signed out", async () => {
+    const renderer = await renderHomeScreen(null);
+
+    expect(renderer.root.findAllByType(signInMessageType as never).length).toBe(1);
+    expect(renderer.root.findAllByType(FlatList).length).toBe(0);
+  });
+
+  it("shows the app grid and no SignInMessage when signed in", async () => {
+    const renderer = await renderHomeScreen("some-token");
+
+    expect(renderer.root.findAllByType(FlatList).length).toBe(1);
+    expect(renderer.root.findAllByType(signInMessageType as never).length).toBe(0);
+  });
+});

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 import SearchBar from "@/components/SearchBar";
+import SignInMessage from "@/components/SignInMessage";
 import SyncingModal from "@/components/SyncingModal";
 import Widget from "@/components/Widget";
 import { Colors } from "@/constants/Colors";
@@ -58,7 +59,7 @@ export default function HomeScreen() {
   const downloadProgress = useSelector(
     (state: RootState) => state.apps.downloadProgress
   );
-  const { email } = useSelector((state: RootState) => state.auth);
+  const { email, accessToken } = useSelector((state: RootState) => state.auth);
   const isForceUpdate = useSelector(
     (state: RootState) =>
       state.appConfig.configs.find(
@@ -276,6 +277,20 @@ export default function HomeScreen() {
     }
   }, [searchQuery, apps]);
 
+  if (!accessToken) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.signInContainer}>
+          <View style={styles.overlay}>
+            <View style={styles.modal}>
+              <SignInMessage message="To view your apps, please sign in" />
+            </View>
+          </View>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView
       style={{
@@ -352,6 +367,28 @@ export default function HomeScreen() {
 
 const createStyles = (colorScheme: "light" | "dark") =>
   StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].primaryBackgroundColor,
+      justifyContent: "space-between",
+    },
+    signInContainer: {
+      flex: 1,
+      justifyContent: "space-between",
+    },
+    overlay: {
+      flex: 1,
+      backgroundColor: Colors[colorScheme].primaryBackgroundColor,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    modal: {
+      backgroundColor: Colors[colorScheme].primaryBackgroundColor,
+      padding: 30,
+      borderRadius: 16,
+      width: "90%",
+      alignItems: "center",
+    },
     searchContainer: {
       flexDirection: "row",
       alignItems: "center",

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -17,6 +17,7 @@ import Avatar from "@/components/Avatar";
 import ProfileListItem from "@/components/ProfileListItem";
 import SignInMessage from "@/components/SignInMessage";
 import { Colors } from "@/constants/Colors";
+import { SUPER_APP_DEVELOPER_GROUP } from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { disableFCMToken } from "@/context/slices/deviceSlice";
 import { getUserInfo } from "@/context/slices/userInfoSlice";
@@ -29,7 +30,7 @@ import { performLogout } from "@/utils/performLogout";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
 import { jwtDecode } from "jwt-decode";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Image,
@@ -61,6 +62,16 @@ const SettingsScreen = () => {
   });
 
   useTrackActiveScreen(ScreenPaths.PROFILE);
+
+  const isSuperAppDeveloper = useMemo(() => {
+    if (!accessToken || !SUPER_APP_DEVELOPER_GROUP) return false;
+    try {
+      const decoded = jwtDecode<DecodedAccessToken>(accessToken);
+      return decoded.groups?.includes(SUPER_APP_DEVELOPER_GROUP) ?? false;
+    } catch {
+      return false;
+    }
+  }, [accessToken]);
 
   useEffect(() => {
     if (userInfo) {
@@ -114,6 +125,21 @@ const SettingsScreen = () => {
       ]
     );
   }, [dispatch]);
+
+  /**
+   * Dev-only: fires the same onLogout callback that refreshAccessToken()/
+   * apiRequest() invoke when a refresh-token exchange comes back 400, or an
+   * API call still 401's after a refresh retry (see services/authService.ts,
+   * utils/requestHandler.ts). Lets us verify the silent-logout UI reacts
+   * correctly without waiting for a real token to expire.
+   */
+  const handleSimulateSilentLogout = useCallback(async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error("Error simulating silent logout:", error);
+    }
+  }, []);
 
   if (!accessToken) {
     return (
@@ -187,6 +213,18 @@ const SettingsScreen = () => {
             <Text style={styles.logoutText}>Sign Out</Text>
           </View>
         </TouchableOpacity>
+
+        {__DEV__ && isSuperAppDeveloper && (
+          <TouchableOpacity
+            activeOpacity={0.5}
+            style={styles.debugLogoutButton}
+            onPress={handleSimulateSilentLogout}
+          >
+            <Text style={styles.debugLogoutText}>
+              DEV: Simulate Silent Logout (401)
+            </Text>
+          </TouchableOpacity>
+        )}
       </View>
     </SafeAreaView>
   );
@@ -263,6 +301,21 @@ const createStyles = (colorScheme: "light" | "dark") =>
       fontSize: 16,
       lineHeight: 20,
       color: Colors[colorScheme].primaryBackgroundColor,
+      fontWeight: "600",
+    },
+    debugLogoutButton: {
+      marginHorizontal: 60,
+      paddingVertical: 12,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: Colors[colorScheme].borderColor,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    debugLogoutText: {
+      fontSize: 13,
+      lineHeight: 18,
+      color: Colors[colorScheme].mutedTextColor,
       fontWeight: "600",
     },
   });

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -23,6 +23,7 @@ import { getUserConfigurations } from "@/context/slices/userConfigSlice";
 import { setUserInfo } from "@/context/slices/userInfoSlice";
 import { getVersions } from "@/context/slices/versionSlice";
 import { AppDispatch, persistor, store } from "@/context/store";
+import { useAuthLogoutListener } from "@/hooks/useAuthLogoutListener";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { useNotificationNavigation } from "@/hooks/useNotificationNavigation";
 import { usePushNotificationHandler } from "@/hooks/usePushNotificationHandler";
@@ -70,6 +71,8 @@ function AppInitializer({ onReady }: { onReady: () => void }) {
   usePushNotificationHandler({ onLogout: handleLogout });
 
   useNotificationNavigation();
+
+  useAuthLogoutListener();
 
   const queryClient = useQueryClient();
 

--- a/frontend/constants/Constants.ts
+++ b/frontend/constants/Constants.ts
@@ -50,6 +50,9 @@ export const DEVELOPER_APP_IOS_DEFAULT_URL =
 export const DEVELOPER_APP_ANDROID_DEFAULT_URL =
   process.env.EXPO_PUBLIC_DEVELOPER_APP_ANDROID_DEFAULT_URL ?? "";
 export const ENABLE_FIREBASE = process.env.EXPO_PUBLIC_ENABLE_FIREBASE === TRUE;
+// Gates dev-only features 
+export const SUPER_APP_DEVELOPER_GROUP =
+  process.env.EXPO_PUBLIC_SUPER_APP_DEVELOPER_GROUP ?? "";
 export const GOOGLE_SCOPES = [
   "openid",
   "profile",

--- a/frontend/constants/enums/Event.ts
+++ b/frontend/constants/enums/Event.ts
@@ -15,4 +15,5 @@
 // under the License.
 export enum Event {
   QrScanned = "qr_scanned",
+  AuthLoggedOut = "auth_logged_out",
 }

--- a/frontend/hooks/__tests__/useAuthLogoutListener.test.ts
+++ b/frontend/hooks/__tests__/useAuthLogoutListener.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Mocked to avoid pulling in @reduxjs/toolkit's ESM `immer` dependency, which
+// this project's Jest transform isn't configured for (see
+// utils/__tests__/microAppCacheStore.test.ts for the same precedent). These
+// stubs mirror the real action creators' shapes exactly.
+jest.mock("@/context/slices/authSlice", () => ({
+  resetAll: () => ({ type: "auth/resetAll" }),
+}));
+jest.mock("@/context/slices/deviceSlice", () => ({
+  clearDeviceState: () => ({ type: "device/clearDeviceState" }),
+  clearLastSentFcmToken: () => ({ type: "device/clearLastSentFcmToken" }),
+}));
+
+const mockDispatch = jest.fn();
+jest.mock("react-redux", () => ({ useDispatch: () => mockDispatch }));
+
+import { Event } from "@/constants/enums/Event";
+import { authEmitter } from "@/utils/eventEmitter";
+import { useAuthLogoutListener } from "@/hooks/useAuthLogoutListener";
+import { createElement } from "react";
+import { act, create } from "react-test-renderer";
+
+function TestHost() {
+  useAuthLogoutListener();
+  return null;
+}
+
+describe("useAuthLogoutListener", () => {
+  afterEach(() => {
+    mockDispatch.mockClear();
+    authEmitter.removeAllListeners();
+  });
+
+  it("subscribes on mount without dispatching anything yet", () => {
+    act(() => {
+      create(createElement(TestHost));
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches resetAll, clearDeviceState, and clearLastSentFcmToken in order when Event.AuthLoggedOut fires", () => {
+    act(() => {
+      create(createElement(TestHost));
+    });
+
+    act(() => {
+      authEmitter.emit(Event.AuthLoggedOut, undefined);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledTimes(3);
+    expect(mockDispatch).toHaveBeenNthCalledWith(1, { type: "auth/resetAll" });
+    expect(mockDispatch).toHaveBeenNthCalledWith(2, {
+      type: "device/clearDeviceState",
+    });
+    expect(mockDispatch).toHaveBeenNthCalledWith(3, {
+      type: "device/clearLastSentFcmToken",
+    });
+  });
+
+  it("stops dispatching after unmount (cleanup unsubscribes)", () => {
+    let root: ReturnType<typeof create> | undefined;
+    act(() => {
+      root = create(createElement(TestHost));
+    });
+
+    act(() => {
+      root!.unmount();
+    });
+
+    act(() => {
+      authEmitter.emit(Event.AuthLoggedOut, undefined);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/hooks/useAuthLogoutListener.ts
+++ b/frontend/hooks/useAuthLogoutListener.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { Event } from "@/constants/enums/Event";
+import { resetAll } from "@/context/slices/authSlice";
+import { clearDeviceState, clearLastSentFcmToken } from "@/context/slices/deviceSlice";
+import { AppDispatch } from "@/context/store";
+import { authEmitter } from "@/utils/eventEmitter";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+/**
+ * Clears Redux state after authService's logout() has finished wiping local
+ * storage, so screens don't keep showing stale data from a session that no
+ * longer exists (e.g. after a silent logout from an expired refresh token).
+ */
+export const useAuthLogoutListener = () => {
+  const dispatch = useDispatch<AppDispatch>();
+
+  useEffect(() => {
+    const unsubscribe = authEmitter.on(Event.AuthLoggedOut, () => {
+      // Not performLogout(): this listener runs *after* logout() has already
+      // cleared local state, so re-triggering it here would be a re-entrant loop.
+      dispatch(resetAll());
+      dispatch(clearDeviceState());
+      dispatch(clearLastSentFcmToken());
+    });
+
+    return unsubscribe;
+  }, [dispatch]);
+};

--- a/frontend/services/__tests__/authService.logout.test.ts
+++ b/frontend/services/__tests__/authService.logout.test.ts
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);
+// Mocked to avoid pulling in @reduxjs/toolkit's ESM `immer` dependency, which
+// this project's Jest transform isn't configured for. The two action
+// creators are plain functions in the real slice; these stubs mirror that.
+jest.mock("@/context/slices/appSlice", () => ({
+  updateExchangedIdToken: (payload: unknown) => ({
+    type: "app/updateExchangedIdToken",
+    payload,
+  }),
+  updateExchangedToken: (payload: unknown) => ({
+    type: "app/updateExchangedToken",
+    payload,
+  }),
+}));
+// authService.logout() throws if LOGOUT_URL is falsy; jest doesn't load the
+// EXPO_PUBLIC_* env vars .env supplies at build/run time, so the real
+// Constants module would leave it undefined here.
+jest.mock("@/constants/Constants", () => ({
+  APPS: "apps",
+  CLIENT_ID: "test-client-id",
+  LOGOUT_URL: "https://example.com/logout",
+  REDIRECT_URI: "https://example.com/redirect",
+  SUCCESS: "success",
+  TOKEN_URL: "https://example.com/token",
+  USER_INFO: "user-info",
+}));
+jest.mock("@/utils/authTokenStore", () => ({
+  loadAuthDataFromSecureStore: jest.fn(),
+  clearAuthDataFromSecureStore: jest.fn(),
+  saveAuthDataToSecureStore: jest.fn(),
+}));
+jest.mock("@/utils/exchangedTokenStore", () => ({
+  clearAllExchangedTokens: jest.fn(),
+}));
+jest.mock("react-native-app-auth", () => ({
+  logout: jest.fn(),
+}));
+
+import { logout } from "@/services/authService";
+import { Event } from "@/constants/enums/Event";
+import {
+  clearAuthDataFromSecureStore,
+  loadAuthDataFromSecureStore,
+} from "@/utils/authTokenStore";
+import { authEmitter } from "@/utils/eventEmitter";
+import { clearAllExchangedTokens } from "@/utils/exchangedTokenStore";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Alert } from "react-native";
+import { logout as appLogout } from "react-native-app-auth";
+
+describe("logout", () => {
+  let emitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Alert, "alert").mockImplementation(() => undefined);
+    emitSpy = jest.spyOn(authEmitter, "emit");
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
+    authEmitter.removeAllListeners();
+  });
+
+  it("does not emit AuthLoggedOut when there is no stored auth data", async () => {
+    (loadAuthDataFromSecureStore as jest.Mock).mockResolvedValue(null);
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears local state and emits AuthLoggedOut once when idToken is missing", async () => {
+    (loadAuthDataFromSecureStore as jest.Mock).mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken: undefined,
+    });
+
+    await logout();
+
+    expect(clearAllExchangedTokens).toHaveBeenCalled();
+    expect(clearAuthDataFromSecureStore).toHaveBeenCalled();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith("user-info");
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(Event.AuthLoggedOut, undefined);
+  });
+
+  it("clears local state and emits AuthLoggedOut once after a successful Asgardeo logout", async () => {
+    (loadAuthDataFromSecureStore as jest.Mock).mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken: "id-token",
+    });
+    (appLogout as jest.Mock).mockResolvedValue(undefined);
+
+    await logout();
+
+    expect(appLogout).toHaveBeenCalled();
+    expect(clearAllExchangedTokens).toHaveBeenCalled();
+    expect(clearAuthDataFromSecureStore).toHaveBeenCalled();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith("user-info");
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(Event.AuthLoggedOut, undefined);
+  });
+
+  it("does not emit AuthLoggedOut when the Asgardeo logout request fails", async () => {
+    (loadAuthDataFromSecureStore as jest.Mock).mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      idToken: "id-token",
+    });
+    (appLogout as jest.Mock).mockRejectedValue(new Error("network error"));
+
+    await expect(logout()).rejects.toThrow("network error");
+
+    expect(Alert.alert).toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -23,6 +23,7 @@ import {
   TOKEN_URL,
   USER_INFO,
 } from "@/constants/Constants";
+import { Event } from "@/constants/enums/Event";
 import {
   updateExchangedIdToken,
   updateExchangedToken,
@@ -36,6 +37,7 @@ import {
   saveAuthDataToSecureStore,
   SecureAuthData,
 } from "@/utils/authTokenStore";
+import { authEmitter } from "@/utils/eventEmitter";
 import { clearAllExchangedTokens } from "@/utils/exchangedTokenStore";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import axios from "axios";
@@ -244,6 +246,7 @@ export const logout = async () => {
       await clearAllExchangedTokens(appIds);
       await clearAuthDataFromSecureStore();
       await AsyncStorage.removeItem(USER_INFO);
+      authEmitter.emit(Event.AuthLoggedOut, undefined);
       return;
     }
 
@@ -255,6 +258,7 @@ export const logout = async () => {
     await clearAllExchangedTokens(appIds);
     await clearAuthDataFromSecureStore();
     await AsyncStorage.removeItem(USER_INFO);
+    authEmitter.emit(Event.AuthLoggedOut, undefined);
   } catch (error) {
     console.error("Error logging out from Asgardeo:", error);
     Alert.alert(

--- a/frontend/types/decodeAccessToken.types.ts
+++ b/frontend/types/decodeAccessToken.types.ts
@@ -18,4 +18,5 @@ export type DecodedAccessToken = {
   given_name?: string;
   family_name?: string;
   userid?: string;
+  groups?: string[];
 };

--- a/frontend/utils/__tests__/eventEmitter.test.ts
+++ b/frontend/utils/__tests__/eventEmitter.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { Event } from "@/constants/enums/Event";
+import { authEmitter, qrScannerEmitter } from "@/utils/eventEmitter";
+
+describe("qrScannerEmitter (existing behavior, guards against regressions)", () => {
+  afterEach(() => {
+    qrScannerEmitter.removeAllListeners();
+  });
+
+  it("calls a subscribed handler with the emitted payload", () => {
+    const handler = jest.fn();
+    qrScannerEmitter.on(Event.QrScanned, handler);
+
+    qrScannerEmitter.emit(Event.QrScanned, "some-qr-payload");
+
+    expect(handler).toHaveBeenCalledWith("some-qr-payload");
+  });
+
+  it("stops calling a handler after the returned unsubscribe is invoked", () => {
+    const handler = jest.fn();
+    const unsubscribe = qrScannerEmitter.on(Event.QrScanned, handler);
+
+    unsubscribe();
+    qrScannerEmitter.emit(Event.QrScanned, "some-qr-payload");
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when emitting with no listeners", () => {
+    expect(() => qrScannerEmitter.emit(Event.QrScanned, "x")).not.toThrow();
+  });
+});
+
+describe("authEmitter", () => {
+  afterEach(() => {
+    authEmitter.removeAllListeners();
+  });
+
+  it("is a distinct instance from qrScannerEmitter", () => {
+    expect(authEmitter).not.toBe(qrScannerEmitter);
+  });
+
+  it("notifies a subscriber when Event.AuthLoggedOut is emitted", () => {
+    const handler = jest.fn();
+    authEmitter.on(Event.AuthLoggedOut, handler);
+
+    authEmitter.emit(Event.AuthLoggedOut, undefined);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not leak events to qrScannerEmitter subscribers", () => {
+    const qrHandler = jest.fn();
+    qrScannerEmitter.on(Event.QrScanned, qrHandler);
+
+    authEmitter.emit(Event.AuthLoggedOut, undefined);
+
+    expect(qrHandler).not.toHaveBeenCalled();
+  });
+
+  it("stops notifying a subscriber after unsubscribing", () => {
+    const handler = jest.fn();
+    const unsubscribe = authEmitter.on(Event.AuthLoggedOut, handler);
+
+    unsubscribe();
+    authEmitter.emit(Event.AuthLoggedOut, undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/utils/eventEmitter.ts
+++ b/frontend/utils/eventEmitter.ts
@@ -80,5 +80,6 @@ class EventEmitter<T> {
 }
 
 const qrScannerEmitter = new EventEmitter<string>();
+const authEmitter = new EventEmitter<void>();
 
-export { qrScannerEmitter };
+export { authEmitter, qrScannerEmitter };


### PR DESCRIPTION
## What
Fixes the apps screen showing stale data after a silent logout (expired refresh token, no user action). Also adds a dev-only button to trigger this on demand for testing.

## Why
`logout()` cleared storage but never touched Redux, so `accessToken` stayed set until the next cold start, and the apps grid kept rendering as if the user was still signed in.

## Changes
- `logout()` now emits an `AuthLoggedOut` event
- New `useAuthLogoutListener` hook resets auth/device redux state when it fires
- `apps/index.tsx` gates on `accessToken`, same as profile/store screens already do
- Dev-only "simulate silent logout" button on the profile screen, so this can be verified without waiting for a real token to expire

## Safety (debug button)
- Only rendered when `__DEV__` is true
- Also requires `EXPO_PUBLIC_SUPER_APP_DEVELOPER_GROUP` to be set and present in the signed-in user's JWT `groups` claim
- Unset/empty env var (the default) hides the button for everyone

## Verified
- New tests pass (`eventEmitter`, `useAuthLogoutListener`, `authService.logout`, apps screen gate)

## Open follow-up (not in this PR)
- Active micro-app webview isn't bounced on silent logout, only tab screens