### PR TITLE
[Frontend] Feature: Business card data model, vCard encoder and token claims

### DIFF
--- a/frontend/constants/BusinessCard.ts
+++ b/frontend/constants/BusinessCard.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// No office address: the wallet service never defaults one either, so
+// hardcoding it here would show a row the installed pass does not have.
+export const CARD_ORGANIZATION = "WSO2 LLC";
+export const CARD_WEBSITE = "https://wso2.com";
+
+// Copied from the wallet service's pass.go. Not Colors.companyOrange
+// (#FF7300) — the signed pass ships this orange, and the Go constant is the
+// source of truth.
+export const PASS_BACKGROUND_COLOR = "#F14E23";
+export const PASS_FOREGROUND_COLOR = "#FFFFFF";
+export const PASS_LABEL_COLOR = "#FFFFFF";
+
+// The card fills the width it is given, so this alone sets its height.
+export const CARD_ASPECT_RATIO = 2 / 3;
+
+// Pass geometry in points, reproduced from the wallet service rather than
+// chosen: the thumbnail ring is 4% of the diameter, as internal/photo draws it.
+export const PASS = {
+  cornerRadius: 16,
+  contentPaddingH: 14,
+  contentPaddingTop: 12,
+  contentPaddingBottom: 14,
+  logoSize: 40,
+  thumbnailSize: 70,
+  thumbnailRingFraction: 0.04,
+  rowGap: 12,
+  barcodeSize: 140,
+  barcodePadding: 10,
+  barcodeCornerRadius: 10,
+} as const;

--- a/frontend/hooks/__tests__/useTokenClaims.test.tsx
+++ b/frontend/hooks/__tests__/useTokenClaims.test.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { useTokenClaims } from "@/hooks/useTokenClaims";
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+import React from "react";
+import { act, create } from "react-test-renderer";
+
+const base64Url = (value: object): string =>
+  Buffer.from(JSON.stringify(value))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+const jwt = (payload: object): string =>
+  `${base64Url({ alg: "RS256" })}.${base64Url(payload)}.sig`;
+
+// The claims the card needs and /user-info never returns.
+const FULL_PAYLOAD = {
+  given_name: "Jane",
+  family_name: "Doe",
+  email: "jane.doe@wso2.com",
+  jobtitle: "Software Engineer",
+  phone_number: "+94771234567",
+  profile: "https://lh3.googleusercontent.com/a-/AAcHTtexampleavatartoken=s100",
+};
+
+// A token with the identity claims but WITHOUT jobtitle/phone_number — the
+// shape Asgardeo hands out when those two are mapped onto the other token.
+const THIN_PAYLOAD = {
+  given_name: "Jane",
+  family_name: "Doe",
+  email: "jane.doe@wso2.com",
+};
+
+let mockAuthState: { accessToken: string | null; idToken: string | null } = {
+  accessToken: null,
+  idToken: null,
+};
+
+jest.mock("react-redux", () => ({
+  useSelector: (selector: (state: unknown) => unknown) =>
+    selector({ auth: mockAuthState }),
+}));
+
+const mockLoadAuthData = jest.fn();
+jest.mock("@/utils/authTokenStore", () => ({
+  loadAuthDataFromSecureStore: () => mockLoadAuthData(),
+}));
+
+/** Renders the hook and hands back whatever it returned. */
+const renderClaims = async (): Promise<DecodedAccessToken | null> => {
+  let captured: DecodedAccessToken | null = null;
+  const Probe = () => {
+    captured = useTokenClaims();
+    return null;
+  };
+  await act(async () => {
+    create(<Probe />);
+  });
+  return captured;
+};
+
+beforeEach(() => {
+  mockAuthState = { accessToken: null, idToken: null };
+  mockLoadAuthData.mockReset();
+  mockLoadAuthData.mockResolvedValue(null);
+});
+
+describe("useTokenClaims", () => {
+  it("reads jobtitle and phone_number from the access token", async () => {
+    mockAuthState = { accessToken: jwt(FULL_PAYLOAD), idToken: null };
+
+    const claims = await renderClaims();
+
+    expect(claims?.jobtitle).toBe("Software Engineer");
+    expect(claims?.phone_number).toBe("+94771234567");
+    // Redux answered, so nothing had to touch the keychain.
+    expect(mockLoadAuthData).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the id token when the access token omits them", async () => {
+    mockAuthState = {
+      accessToken: jwt(THIN_PAYLOAD),
+      idToken: jwt(FULL_PAYLOAD),
+    };
+
+    const claims = await renderClaims();
+
+    expect(claims?.jobtitle).toBe("Software Engineer");
+    expect(claims?.phone_number).toBe("+94771234567");
+  });
+
+  it("reads SecureStore when Redux has no tokens yet", async () => {
+    mockLoadAuthData.mockResolvedValue({
+      accessToken: jwt(FULL_PAYLOAD),
+      idToken: jwt(THIN_PAYLOAD),
+    });
+
+    const claims = await renderClaims();
+
+    expect(claims?.jobtitle).toBe("Software Engineer");
+    expect(claims?.phone_number).toBe("+94771234567");
+  });
+
+  it("reads SecureStore when the Redux access token is opaque", async () => {
+    // Asgardeo can be configured to issue opaque access tokens; jwtDecode
+    // throws on those, and the old code turned that into a silently empty card.
+    mockAuthState = { accessToken: "opaque-not-a-jwt", idToken: null };
+    mockLoadAuthData.mockResolvedValue({
+      accessToken: "opaque-not-a-jwt",
+      idToken: jwt(FULL_PAYLOAD),
+    });
+
+    const claims = await renderClaims();
+
+    expect(claims?.jobtitle).toBe("Software Engineer");
+    expect(claims?.phone_number).toBe("+94771234567");
+  });
+
+  it("returns null when signed out", async () => {
+    expect(await renderClaims()).toBeNull();
+  });
+});

--- a/frontend/hooks/useTokenClaims.ts
+++ b/frontend/hooks/useTokenClaims.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { RootState } from "@/context/store";
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+import { loadAuthDataFromSecureStore } from "@/utils/authTokenStore";
+import { decodeClaims, mergeClaims } from "@/utils/tokenClaims";
+import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+
+export const useTokenClaims = (): DecodedAccessToken | null => {
+  const { accessToken, idToken } = useSelector(
+    (state: RootState) => state.auth
+  );
+  const [storedClaims, setStoredClaims] = useState<DecodedAccessToken | null>(
+    null
+  );
+
+  const reduxClaims = useMemo(
+    () =>
+      mergeClaims([
+        decodeClaims(accessToken, "access token"),
+        decodeClaims(idToken, "id token"),
+      ]),
+    [accessToken, idToken]
+  );
+
+  // A mid-session refresh writes new tokens to SecureStore without dispatching,
+  // and a screen can mount before `restoreAuth` resolves, so Redux having
+  // nothing is not the same as being signed out.
+  const needsFallback = !reduxClaims?.jobtitle && !reduxClaims?.phone_number;
+
+  useEffect(() => {
+    if (!needsFallback) {
+      setStoredClaims(null);
+      return;
+    }
+
+    let cancelled = false;
+    loadAuthDataFromSecureStore()
+      .then((stored) => {
+        if (cancelled) {
+          return;
+        }
+        setStoredClaims(
+          mergeClaims([
+            decodeClaims(stored?.accessToken, "stored access token"),
+            decodeClaims(stored?.idToken, "stored id token"),
+          ])
+        );
+      })
+      .catch((error) => {
+        console.warn("[claims] could not read tokens from SecureStore", error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [needsFallback]);
+
+  return useMemo(
+    () => mergeClaims([reduxClaims, storedClaims]),
+    [reduxClaims, storedClaims]
+  );
+};

--- a/frontend/types/businessCard.types.ts
+++ b/frontend/types/businessCard.types.ts
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -14,17 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Wire claim names, looked up by the exact key the token carries — `jobtitle`
-// and `userid` are Asgardeo's own spellings, not OIDC standard ones, so do not
-// camelCase them.
-export type DecodedAccessToken = {
-  email?: string;
-  given_name?: string;
-  family_name?: string;
-  userid?: string;
-  jobtitle?: string;
-  /** E.164. HR exposes no work number, so the card renders this as the mobile. */
-  phone_number?: string;
-  /** Avatar URL; Google photos carry an `=s100` suffix that callers strip. */
-  profile?: string;
+export type BusinessCardData = {
+  firstName: string;
+  lastName: string;
+  jobTitle?: string;
+  department?: string;
+  workEmail: string;
+  workPhone?: string;
+  mobile?: string; // only present when the user opted in
+  organization: string;
+  website: string;
+  address?: string;
+  photoUri?: string; // NOT encoded into the QR payload
 };

--- a/frontend/utils/__tests__/businessCard.test.ts
+++ b/frontend/utils/__tests__/businessCard.test.ts
@@ -1,0 +1,216 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { CARD_ORGANIZATION, CARD_WEBSITE } from "@/constants/BusinessCard";
+import { UserInfo } from "@/context/slices/userInfoSlice";
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+import {
+  fullResolutionPhotoUri,
+  toBusinessCardData,
+} from "@/utils/businessCard";
+
+const baseUserInfo: UserInfo = {
+  firstName: "Jane",
+  lastName: "Doe",
+  workEmail: "jane.doe@wso2.com",
+  employeeThumbnail: null,
+};
+
+// A representative access-token payload, trimmed to the claims this
+// module reads.
+const baseClaims: DecodedAccessToken = {
+  email: "jane.doe@wso2.com",
+  given_name: "Jane",
+  family_name: "Doe",
+  userid: "00000000-0000-4000-8000-000000000000",
+  jobtitle: "Software Engineer",
+  phone_number: "+94771234567",
+  profile:
+    "https://lh3.googleusercontent.com/a-/AAcHTtexampleavatartoken=s100",
+};
+
+describe("toBusinessCardData — nothing worth putting on a card", () => {
+  it("returns null with no directory data and no claims", () => {
+    expect(toBusinessCardData(null, null)).toBeNull();
+    expect(toBusinessCardData(undefined)).toBeNull();
+  });
+
+  it("returns null when neither source has a name or a workEmail", () => {
+    const result = toBusinessCardData(
+      {
+        firstName: "",
+        lastName: "  ",
+        workEmail: "   ",
+        employeeThumbnail: null,
+      },
+      { jobtitle: "Software Engineer" }
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns data when a name is present even without a workEmail", () => {
+    const result = toBusinessCardData(
+      {
+        firstName: "Jane",
+        lastName: "Doe",
+        workEmail: "   ",
+        employeeThumbnail: null,
+      },
+      null
+    );
+    expect(result).not.toBeNull();
+  });
+
+  it("returns data when a workEmail is present even without a name", () => {
+    const result = toBusinessCardData(
+      {
+        firstName: " ",
+        lastName: " ",
+        workEmail: "jane.doe@wso2.com",
+        employeeThumbnail: null,
+      },
+      null
+    );
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("toBusinessCardData — token claims alone", () => {
+  it("builds a full card from the access token with no directory response", () => {
+    const result = toBusinessCardData(null, baseClaims);
+
+    expect(result).toMatchObject({
+      firstName: "Jane",
+      lastName: "Doe",
+      workEmail: "jane.doe@wso2.com",
+      jobTitle: "Software Engineer",
+      mobile: "+94771234567",
+    });
+  });
+
+  it("takes phone_number as the mobile, never the work phone", () => {
+    const result = toBusinessCardData(null, baseClaims);
+    expect(result?.mobile).toBe("+94771234567");
+    expect(result?.workPhone).toBeUndefined();
+  });
+
+  it("leaves absent claims undefined rather than rendering empty rows", () => {
+    const result = toBusinessCardData(null, {
+      email: "nobody@wso2.com",
+      given_name: "No",
+      family_name: "Body",
+    });
+    expect(result?.jobTitle).toBeUndefined();
+    expect(result?.mobile).toBeUndefined();
+    expect(result?.photoUri).toBeUndefined();
+  });
+});
+
+describe("toBusinessCardData — precedence", () => {
+  it("prefers the directory name and email over the token's", () => {
+    const result = toBusinessCardData(baseUserInfo, baseClaims);
+    expect(result?.firstName).toBe("Jane");
+    expect(result?.lastName).toBe("Doe");
+    expect(result?.workEmail).toBe("jane.doe@wso2.com");
+  });
+
+  it("falls back to the claim when the directory field is blank", () => {
+    const result = toBusinessCardData(
+      { ...baseUserInfo, firstName: "   " },
+      baseClaims
+    );
+    expect(result?.firstName).toBe("Jane");
+  });
+
+  it("prefers a directory job title and mobile over the token's", () => {
+    const result = toBusinessCardData(
+      { ...baseUserInfo, jobTitle: "Staff Engineer", mobile: "+94111111111" },
+      baseClaims
+    );
+    expect(result?.jobTitle).toBe("Staff Engineer");
+    expect(result?.mobile).toBe("+94111111111");
+  });
+
+  it("prefers the directory thumbnail over the token's profile photo", () => {
+    const result = toBusinessCardData(
+      { ...baseUserInfo, employeeThumbnail: "https://hr.example/jane.jpg" },
+      baseClaims
+    );
+    expect(result?.photoUri).toBe("https://hr.example/jane.jpg");
+  });
+});
+
+describe("toBusinessCardData — constants", () => {
+  it("fills organization and website from constants/BusinessCard", () => {
+    const result = toBusinessCardData(baseUserInfo, null);
+    expect(result?.organization).toBe(CARD_ORGANIZATION);
+    expect(result?.website).toBe(CARD_WEBSITE);
+  });
+
+  // The wallet service never defaults an office address, so neither does this.
+  // A card that showed one would be showing a row the installed pass has not
+  // got — and it would ride into the QR payload as an ADR line too.
+  it("leaves the address unset, matching the pass", () => {
+    const result = toBusinessCardData(baseUserInfo, baseClaims);
+    expect(result?.address).toBeUndefined();
+  });
+});
+
+describe("toBusinessCardData — trimming", () => {
+  it("trims whitespace on string fields from either source", () => {
+    const result = toBusinessCardData(
+      {
+        firstName: "  Jane  ",
+        lastName: "  Doe  ",
+        workEmail: "  jane.doe@wso2.com  ",
+        employeeThumbnail: null,
+      },
+      { jobtitle: "  Software Engineer  " }
+    );
+    expect(result?.firstName).toBe("Jane");
+    expect(result?.lastName).toBe("Doe");
+    expect(result?.workEmail).toBe("jane.doe@wso2.com");
+    expect(result?.jobTitle).toBe("Software Engineer");
+  });
+});
+
+describe("fullResolutionPhotoUri", () => {
+  // The same regex the wallet pass service uses on the pass side
+  // (googleSizeHint), so the app and the pass ask the directory for the same
+  // image.
+  it("strips a Google =s<size> suffix", () => {
+    expect(
+      fullResolutionPhotoUri("https://lh3.googleusercontent.com/a-/abc=s100")
+    ).toBe("https://lh3.googleusercontent.com/a-/abc");
+  });
+
+  it("strips a =s<size>-c centre-cropped suffix", () => {
+    expect(
+      fullResolutionPhotoUri("https://lh3.googleusercontent.com/a-/abc=s64-c")
+    ).toBe("https://lh3.googleusercontent.com/a-/abc");
+  });
+
+  it("leaves a URL with no size suffix alone", () => {
+    expect(fullResolutionPhotoUri("https://hr.example/jane.jpg")).toBe(
+      "https://hr.example/jane.jpg"
+    );
+  });
+
+  it("maps blank and nullish input to undefined", () => {
+    expect(fullResolutionPhotoUri(null)).toBeUndefined();
+    expect(fullResolutionPhotoUri(undefined)).toBeUndefined();
+    expect(fullResolutionPhotoUri("   ")).toBeUndefined();
+  });
+});

--- a/frontend/utils/__tests__/vcard.fixture.test.ts
+++ b/frontend/utils/__tests__/vcard.fixture.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// The vCard encoder exists twice, here in TypeScript and again in Go in the
+// wallet pass service, because the QR on the wallet pass and the QR in the app
+// have to scan to the same contact.
+//
+// The two suites used to read one file. The service lives in its own repo, so
+// vcard_cases.json is duplicated beside each suite and neither copy can be
+// edited alone: change one, change the other, or the two encoders diverge
+// silently and someone scans a wrong business card.
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import { BusinessCardData } from "@/types/businessCard.types";
+import { buildVCard } from "@/utils/vcard";
+
+const FIXTURE_PATH = join(__dirname, "vcard_cases.json");
+
+type VCardCase = {
+  name: string;
+  input: BusinessCardData & { serialNumber?: string };
+  expected: string;
+};
+
+const cases: VCardCase[] = JSON.parse(readFileSync(FIXTURE_PATH, "utf8")).cases;
+
+describe("buildVCard — shared fixture with the Go wallet service", () => {
+  it("loads the fixture", () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases.map((c): [string, VCardCase] => [c.name, c]))(
+    "%s",
+    (_name, testCase) => {
+      // Byte comparison, not field comparison. Line order, CRLF between lines
+      // and the trailing CRLF after END:VCARD are all part of the contract.
+      expect(buildVCard(testCase.input)).toBe(testCase.expected);
+    }
+  );
+});

--- a/frontend/utils/__tests__/vcard.test.ts
+++ b/frontend/utils/__tests__/vcard.test.ts
@@ -1,0 +1,308 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { buildVCard, vCardFileName } from "@/utils/vcard";
+import { BusinessCardData } from "@/types/businessCard.types";
+
+const fullData: BusinessCardData = {
+  firstName: "Jane",
+  lastName: "Doe",
+  jobTitle: "Software Engineer",
+  department: "Platform",
+  workEmail: "jane.doe@wso2.com",
+  workPhone: "+94112345678",
+  mobile: "+94771234567",
+  organization: "WSO2 LLC",
+  website: "https://wso2.com",
+  address: "20 Palm Grove, Colombo 03, Sri Lanka",
+  photoUri: "data:image/png;base64,AAAA",
+};
+
+const minimalData: BusinessCardData = {
+  firstName: "Jane",
+  lastName: "Doe",
+  workEmail: "jane.doe@wso2.com",
+  organization: "WSO2 LLC",
+  website: "https://wso2.com",
+};
+
+describe("buildVCard — document structure", () => {
+  it("builds a full vCard 3.0 document with all fields, in order", () => {
+    const vcard = buildVCard(fullData);
+    const expectedLines = [
+      "BEGIN:VCARD",
+      "VERSION:3.0",
+      "N:Doe;Jane;;;",
+      "FN:Jane Doe",
+      "ORG:WSO2 LLC;Platform",
+      "TITLE:Software Engineer",
+      "EMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com",
+      "TEL;TYPE=WORK,VOICE:+94112345678",
+      "TEL;TYPE=CELL,VOICE:+94771234567",
+      "URL:https://wso2.com",
+      "ADR;TYPE=WORK:;;20 Palm Grove\\, Colombo 03\\, Sri Lanka;;;;",
+      "END:VCARD",
+    ];
+    expect(vcard).toBe(expectedLines.join("\r\n") + "\r\n");
+  });
+
+  it("starts with BEGIN:VCARD followed by VERSION:3.0", () => {
+    const lines = buildVCard(minimalData).split("\r\n");
+    expect(lines[0]).toBe("BEGIN:VCARD");
+    expect(lines[1]).toBe("VERSION:3.0");
+  });
+
+  it("ends with END:VCARD and a trailing CRLF", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard.endsWith("END:VCARD\r\n")).toBe(true);
+  });
+
+  it("joins lines with CRLF, never a bare LF", () => {
+    const vcard = buildVCard(fullData);
+    expect(vcard.includes("\r\n")).toBe(true);
+    expect(vcard.replace(/\r\n/g, "").includes("\n")).toBe(false);
+  });
+});
+
+describe("buildVCard — N and FN", () => {
+  it("emits N:Last;First;;; and FN:First Last", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).toContain("N:Doe;Jane;;;\r\n");
+    expect(vcard).toContain("FN:Jane Doe\r\n");
+  });
+
+  it("FN has no stray space when lastName is empty", () => {
+    const vcard = buildVCard({ ...minimalData, lastName: "" });
+    expect(vcard).toContain("FN:Jane\r\n");
+    expect(vcard).not.toContain("FN:Jane \r\n");
+  });
+
+  it("FN has no stray space when firstName is empty", () => {
+    const vcard = buildVCard({ ...minimalData, firstName: "" });
+    expect(vcard).toContain("FN:Doe\r\n");
+    expect(vcard).not.toContain("FN: Doe\r\n");
+  });
+});
+
+describe("buildVCard — ORG", () => {
+  it("emits ORG:Organization;Department when department is present", () => {
+    const vcard = buildVCard({ ...minimalData, department: "Platform" });
+    expect(vcard).toContain("ORG:WSO2 LLC;Platform\r\n");
+  });
+
+  it("emits ORG:Organization only when department is absent", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).toContain("ORG:WSO2 LLC\r\n");
+  });
+
+  it("emits ORG:Organization only when department is whitespace-only", () => {
+    const vcard = buildVCard({ ...minimalData, department: "   " });
+    expect(vcard).toContain("ORG:WSO2 LLC\r\n");
+  });
+});
+
+describe("buildVCard — TITLE", () => {
+  it("emits TITLE when jobTitle is a non-empty string", () => {
+    const vcard = buildVCard({ ...minimalData, jobTitle: "Software Engineer" });
+    expect(vcard).toContain("TITLE:Software Engineer\r\n");
+  });
+
+  it("omits TITLE when jobTitle is undefined", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).not.toContain("TITLE:");
+  });
+
+  it("omits TITLE when jobTitle is whitespace-only", () => {
+    const vcard = buildVCard({ ...minimalData, jobTitle: "   " });
+    expect(vcard).not.toContain("TITLE:");
+  });
+});
+
+describe("buildVCard — EMAIL and URL", () => {
+  it("emits EMAIL;TYPE=INTERNET,WORK: for workEmail", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).toContain("EMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\n");
+  });
+
+  it("emits URL: for website", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).toContain("URL:https://wso2.com\r\n");
+  });
+});
+
+describe("buildVCard — TEL", () => {
+  it("emits TEL;TYPE=WORK,VOICE: when workPhone is present", () => {
+    const vcard = buildVCard({ ...minimalData, workPhone: "+94112345678" });
+    expect(vcard).toContain("TEL;TYPE=WORK,VOICE:+94112345678\r\n");
+  });
+
+  it("omits the WORK TEL line when workPhone is absent", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).not.toContain("TYPE=WORK,VOICE");
+  });
+
+  it("omits the WORK TEL line when workPhone is whitespace-only", () => {
+    const vcard = buildVCard({ ...minimalData, workPhone: "   " });
+    expect(vcard).not.toContain("TYPE=WORK,VOICE");
+  });
+
+  it("emits TEL;TYPE=CELL,VOICE: when mobile is present (opted in)", () => {
+    const vcard = buildVCard({ ...minimalData, mobile: "+94771234567" });
+    expect(vcard).toContain("TEL;TYPE=CELL,VOICE:+94771234567\r\n");
+  });
+
+  it("never emits a CELL TEL line when mobile is undefined (privacy opt-in guarantee)", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).not.toContain("TYPE=CELL,VOICE");
+  });
+
+  it("never emits a CELL TEL line when mobile is an empty string", () => {
+    const vcard = buildVCard({ ...minimalData, mobile: "" });
+    expect(vcard).not.toContain("TYPE=CELL,VOICE");
+  });
+
+  it("never emits a CELL TEL line when mobile is whitespace-only", () => {
+    const vcard = buildVCard({ ...minimalData, mobile: "   " });
+    expect(vcard).not.toContain("TYPE=CELL,VOICE");
+  });
+});
+
+describe("buildVCard — ADR", () => {
+  it("emits ADR;TYPE=WORK:;;<address>;;;; when address is present", () => {
+    const vcard = buildVCard({ ...minimalData, address: "20 Palm Grove" });
+    expect(vcard).toContain("ADR;TYPE=WORK:;;20 Palm Grove;;;;\r\n");
+  });
+
+  it("omits ADR when address is absent", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).not.toContain("ADR;TYPE=WORK");
+  });
+
+  it("omits ADR when address is whitespace-only", () => {
+    const vcard = buildVCard({ ...minimalData, address: "   " });
+    expect(vcard).not.toContain("ADR;TYPE=WORK");
+  });
+});
+
+describe("buildVCard — PHOTO must never appear", () => {
+  it("never emits a PHOTO line, even when photoUri is a data URI", () => {
+    const vcard = buildVCard({
+      ...minimalData,
+      photoUri: "data:image/png;base64,iVBORw0KGgoAAAANSU",
+    });
+    expect(vcard).not.toContain("PHOTO");
+    expect(vcard).not.toContain("data:image");
+    expect(vcard).not.toContain("base64");
+  });
+
+  it("never emits a PHOTO line when photoUri is absent", () => {
+    const vcard = buildVCard(minimalData);
+    expect(vcard).not.toContain("PHOTO");
+  });
+});
+
+describe("buildVCard — escaping (RFC 2426)", () => {
+  it("escapes commas in ORG, e.g. WSO2, LLC", () => {
+    const vcard = buildVCard({ ...minimalData, organization: "WSO2, LLC" });
+    expect(vcard).toContain("ORG:WSO2\\, LLC\r\n");
+  });
+
+  it("escapes semicolons in a text value", () => {
+    const vcard = buildVCard({ ...minimalData, department: "R&D; Platform" });
+    expect(vcard).toContain("ORG:WSO2 LLC;R&D\\; Platform\r\n");
+  });
+
+  it("escapes backslashes in a text value", () => {
+    const vcard = buildVCard({ ...minimalData, department: "Team\\Alpha" });
+    expect(vcard).toContain("ORG:WSO2 LLC;Team\\\\Alpha\r\n");
+  });
+
+  it("escapes newlines in a multi-line address as literal \\n", () => {
+    const vcard = buildVCard({
+      ...minimalData,
+      address: "20 Palm Grove\nColombo 03\nSri Lanka",
+    });
+    expect(vcard).toContain(
+      "ADR;TYPE=WORK:;;20 Palm Grove\\nColombo 03\\nSri Lanka;;;;\r\n"
+    );
+  });
+
+  it("escapes commas and semicolons together in the address", () => {
+    const vcard = buildVCard({
+      ...minimalData,
+      address: "20 Palm Grove, Colombo 03; Sri Lanka",
+    });
+    expect(vcard).toContain(
+      "ADR;TYPE=WORK:;;20 Palm Grove\\, Colombo 03\\; Sri Lanka;;;;\r\n"
+    );
+  });
+});
+
+describe("buildVCard — UTF-8 safety", () => {
+  it("passes non-ASCII Sinhala names through unmodified", () => {
+    const vcard = buildVCard({
+      ...minimalData,
+      firstName: "සමන්",
+      lastName: "පෙරේරා",
+    });
+    expect(vcard).toContain("N:පෙරේරා;සමන්;;;\r\n");
+    expect(vcard).toContain("FN:සමන් පෙරේරා\r\n");
+  });
+
+  it("passes accented Latin names through unmodified", () => {
+    const vcard = buildVCard({ ...minimalData, firstName: "Zoë", lastName: "Müller" });
+    expect(vcard).toContain("N:Müller;Zoë;;;\r\n");
+    expect(vcard).toContain("FN:Zoë Müller\r\n");
+  });
+});
+
+describe("vCardFileName", () => {
+  it("builds a First_Last.vcf filename", () => {
+    expect(vCardFileName(minimalData)).toBe("Jane_Doe.vcf");
+  });
+
+  it("keeps non-ASCII letters as-is", () => {
+    expect(vCardFileName({ ...minimalData, firstName: "Zoë", lastName: "Müller" })).toBe(
+      "Zoë_Müller.vcf"
+    );
+  });
+
+  it("replaces filesystem-unsafe characters with underscores", () => {
+    const name = vCardFileName({ ...minimalData, firstName: "John/Doe", lastName: "A:B" });
+    expect(name).not.toMatch(/[/\\:*?"<>|]/);
+    expect(name.endsWith(".vcf")).toBe(true);
+  });
+
+  it("collapses repeated underscores", () => {
+    const name = vCardFileName({ ...minimalData, firstName: "John   /  Doe", lastName: "" });
+    expect(name).not.toMatch(/_{2,}/);
+  });
+
+  it("cannot be used for path traversal", () => {
+    const name = vCardFileName({ ...minimalData, firstName: "../../etc", lastName: "passwd" });
+    expect(name).not.toContain("/");
+    expect(name).not.toContain("\\");
+  });
+
+  it("falls back to contact.vcf when the name yields nothing usable", () => {
+    expect(vCardFileName({ ...minimalData, firstName: "   ", lastName: "" })).toBe("contact.vcf");
+  });
+
+  it("falls back to contact.vcf when the name is only unsafe characters", () => {
+    expect(vCardFileName({ ...minimalData, firstName: "///", lastName: ":::" })).toBe(
+      "contact.vcf"
+    );
+  });
+});

--- a/frontend/utils/__tests__/vcard_cases.json
+++ b/frontend/utils/__tests__/vcard_cases.json
@@ -1,0 +1,179 @@
+{
+  "_comment": [
+    "Canonical vCard specification, shared by two implementations: this app's",
+    "encoder (frontend/utils/vcard.ts) and the wallet pass service's Go one.",
+    "The implementations live in different repos, so this file is duplicated:",
+    "one copy beside each suite. Edit both or the encoders diverge silently.",
+    "Expected values are hand-derived from RFC 2426 and frontend/utils/vcard.ts,",
+    "never regenerated from an implementation — that would make the fixture agree",
+    "with a bug. Escape order is backslash, semicolon, comma, then newlines."
+  ],
+  "cases": [
+    {
+      "name": "full — every optional field present",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "jobTitle": "Software Engineer",
+        "department": "Platform",
+        "workEmail": "jane.doe@wso2.com",
+        "workPhone": "+94112345678",
+        "mobile": "+94771234567",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com",
+        "address": "20 Palm Grove, Colombo 03, Sri Lanka"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC;Platform\r\nTITLE:Software Engineer\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nTEL;TYPE=WORK,VOICE:+94112345678\r\nTEL;TYPE=CELL,VOICE:+94771234567\r\nURL:https://wso2.com\r\nADR;TYPE=WORK:;;20 Palm Grove\\, Colombo 03\\, Sri Lanka;;;;\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "minimal — every optional field absent",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "workEmail": "jane.doe@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "whitespace-only optionals are absent, not empty",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "jobTitle": "   ",
+        "department": "  ",
+        "workEmail": "jane.doe@wso2.com",
+        "workPhone": " ",
+        "mobile": "   ",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com",
+        "address": "\t "
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "shape of a real signed pass — comma in department and address",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "jobTitle": "Senior Customer Success Engineer",
+        "department": "Customer Success, Sri Lanka",
+        "workEmail": "jane.doe@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com",
+        "address": "10900 Stonelake Blvd Bldg 2 Ste 100, Austin, TX, US"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC;Customer Success\\, Sri Lanka\r\nTITLE:Senior Customer Success Engineer\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nURL:https://wso2.com\r\nADR;TYPE=WORK:;;10900 Stonelake Blvd Bldg 2 Ste 100\\, Austin\\, TX\\, US;;;;\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "escape order — backslash before semicolon before comma",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "department": "R&D; Platform\\Alpha, Team",
+        "workEmail": "jane.doe@wso2.com",
+        "organization": "WSO2, LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2\\, LLC;R&D\\; Platform\\\\Alpha\\, Team\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "CRLF, CR and LF all collapse to a literal backslash-n",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "workEmail": "jane.doe@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com",
+        "address": "20 Palm Grove\r\nColombo 03\nSri Lanka\rLK"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nURL:https://wso2.com\r\nADR;TYPE=WORK:;;20 Palm Grove\\nColombo 03\\nSri Lanka\\nLK;;;;\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "Sinhala name survives unmodified",
+      "input": {
+        "firstName": "සමන්",
+        "lastName": "පෙරේරා",
+        "jobTitle": "ඉංජිනේරු",
+        "workEmail": "saman@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:පෙරේරා;සමන්;;;\r\nFN:සමන් පෙරේරා\r\nORG:WSO2 LLC\r\nTITLE:ඉංජිනේරු\r\nEMAIL;TYPE=INTERNET,WORK:saman@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "Tamil name survives unmodified",
+      "input": {
+        "firstName": "அருண்",
+        "lastName": "குமார்",
+        "workEmail": "arun@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:குமார்;அருண்;;;\r\nFN:அருண் குமார்\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:arun@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "accented Latin name survives unmodified",
+      "input": {
+        "firstName": "Zoë",
+        "lastName": "Müller",
+        "workEmail": "zoe@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Müller;Zoë;;;\r\nFN:Zoë Müller\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:zoe@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "empty last name leaves no stray space in FN",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "",
+        "workEmail": "jane@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:;Jane;;;\r\nFN:Jane\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:jane@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "empty first name leaves no leading space in FN",
+      "input": {
+        "firstName": "",
+        "lastName": "Doe",
+        "workEmail": "doe@wso2.com",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;;;;\r\nFN:Doe\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:doe@wso2.com\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "surrounding whitespace is trimmed from every field",
+      "input": {
+        "firstName": "  Jane  ",
+        "lastName": " Doe ",
+        "jobTitle": " Software Engineer ",
+        "department": " Platform ",
+        "workEmail": " jane.doe@wso2.com ",
+        "workPhone": " +94112345678 ",
+        "mobile": " +94771234567 ",
+        "organization": " WSO2 LLC ",
+        "website": " https://wso2.com ",
+        "address": " 20 Palm Grove "
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC;Platform\r\nTITLE:Software Engineer\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nTEL;TYPE=WORK,VOICE:+94112345678\r\nTEL;TYPE=CELL,VOICE:+94771234567\r\nURL:https://wso2.com\r\nADR;TYPE=WORK:;;20 Palm Grove;;;;\r\nEND:VCARD\r\n"
+    },
+    {
+      "name": "mobile absent is a privacy guarantee, never an empty TEL line",
+      "input": {
+        "firstName": "Jane",
+        "lastName": "Doe",
+        "workEmail": "jane.doe@wso2.com",
+        "workPhone": "+94112345678",
+        "mobile": "",
+        "organization": "WSO2 LLC",
+        "website": "https://wso2.com"
+      },
+      "expected": "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;Jane;;;\r\nFN:Jane Doe\r\nORG:WSO2 LLC\r\nEMAIL;TYPE=INTERNET,WORK:jane.doe@wso2.com\r\nTEL;TYPE=WORK,VOICE:+94112345678\r\nURL:https://wso2.com\r\nEND:VCARD\r\n"
+    }
+  ]
+}

--- a/frontend/utils/businessCard.ts
+++ b/frontend/utils/businessCard.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { CARD_ORGANIZATION, CARD_WEBSITE } from "@/constants/BusinessCard";
+import { UserInfo } from "@/context/slices/userInfoSlice";
+import { BusinessCardData } from "@/types/businessCard.types";
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+
+// Optional because /user-info only returns the four `UserInfo` fields; the
+// richer HR shape reaches the wallet service by its own route.
+type DirectoryUserInfo = UserInfo &
+  Partial<{
+    jobTitle: string;
+    department: string;
+    workPhone: string;
+    mobile: string;
+  }>;
+
+const hasText = (value: string | undefined | null): value is string =>
+  value !== undefined && value !== null && value.trim().length > 0;
+
+const trimmedOrUndefined = (
+  value: string | undefined | null
+): string | undefined => (hasText(value) ? value.trim() : undefined);
+
+// The precedence rule the module runs on: the directory answer wins where
+// there is one, the token claim fills the gap.
+const firstPresent = (
+  ...values: (string | undefined | null)[]
+): string | undefined => {
+  for (const value of values) {
+    const trimmed = trimmedOrUndefined(value);
+    if (trimmed !== undefined) {
+      return trimmed;
+    }
+  }
+  return undefined;
+};
+
+// Dropping the size suffix Google avatar URLs carry yields the full-resolution
+// image, which the pass needs for its 90pt thumbnail.
+const GOOGLE_PHOTO_SIZE_SUFFIX = /=s\d+(-c)?$/;
+
+export const fullResolutionPhotoUri = (
+  url: string | undefined | null
+): string | undefined => {
+  const trimmed = trimmedOrUndefined(url);
+  return trimmed?.replace(GOOGLE_PHOTO_SIZE_SUFFIX, "");
+};
+
+// Either source alone is enough: the claims are what make the card work on a
+// cold start before /user-info answers, and the only source of `jobtitle` and
+// `phone_number` today.
+//
+// `mobile` is deliberately not gated behind an opt-in. The wallet service puts
+// the number on the pass unconditionally, so hiding it here would make the
+// preview a lie about what is being installed. If that gate lands in the
+// service, add it in both places at once.
+export const toBusinessCardData = (
+  userInfo: DirectoryUserInfo | null | undefined,
+  claims?: DecodedAccessToken | null
+): BusinessCardData | null => {
+  const firstName = firstPresent(userInfo?.firstName, claims?.given_name) ?? "";
+  const lastName = firstPresent(userInfo?.lastName, claims?.family_name) ?? "";
+  const workEmail = firstPresent(userInfo?.workEmail, claims?.email) ?? "";
+
+  // The screen renders its own empty state rather than a blank card.
+  if (!firstName && !lastName && !workEmail) {
+    return null;
+  }
+
+  return {
+    firstName,
+    lastName,
+    jobTitle: firstPresent(userInfo?.jobTitle, claims?.jobtitle),
+    department: trimmedOrUndefined(userInfo?.department),
+    workEmail,
+    // backend/utils.bal hardcodes workPhone to nil, so `mobile` is the number
+    // that actually renders today.
+    workPhone: trimmedOrUndefined(userInfo?.workPhone),
+    mobile: firstPresent(userInfo?.mobile, claims?.phone_number),
+    organization: CARD_ORGANIZATION,
+    website: CARD_WEBSITE,
+    // No address: nothing on the client supplies one and the pass has no
+    // OFFICE row, though the vCard builder still writes ADR when given one.
+    photoUri: fullResolutionPhotoUri(
+      firstPresent(userInfo?.employeeThumbnail, claims?.profile)
+    ),
+  };
+};

--- a/frontend/utils/tokenClaims.ts
+++ b/frontend/utils/tokenClaims.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+import { jwtDecode } from "jwt-decode";
+
+// Asgardeo can be configured to issue opaque access tokens, so failing to
+// decode is expected rather than an error; the caller falls back to the other
+// token.
+export const decodeClaims = (
+  token: string | null | undefined,
+  source: string
+): DecodedAccessToken | null => {
+  if (!token) {
+    return null;
+  }
+  try {
+    return jwtDecode<DecodedAccessToken>(token);
+  } catch (error) {
+    console.warn(`[claims] ${source} is not a decodable JWT`, error);
+    return null;
+  }
+};
+
+// Merged field by field rather than picking one token wholesale: Asgardeo puts
+// `jobtitle` and `phone_number` in whichever token the OIDC app's claim config
+// names, and that differs per app and can move between releases.
+export const mergeClaims = (
+  sources: (DecodedAccessToken | null)[]
+): DecodedAccessToken | null => {
+  const present = sources.filter((claims): claims is DecodedAccessToken =>
+    Boolean(claims)
+  );
+  if (present.length === 0) {
+    return null;
+  }
+
+  const pick = (key: keyof DecodedAccessToken): string | undefined => {
+    for (const claims of present) {
+      const value = claims[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
+  return {
+    email: pick("email"),
+    given_name: pick("given_name"),
+    family_name: pick("family_name"),
+    userid: pick("userid"),
+    jobtitle: pick("jobtitle"),
+    phone_number: pick("phone_number"),
+    profile: pick("profile"),
+  };
+};

--- a/frontend/utils/vcard.ts
+++ b/frontend/utils/vcard.ts
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { BusinessCardData } from "@/types/businessCard.types";
+
+const CRLF = "\r\n";
+
+const hasValue = (value: string | undefined): value is string =>
+  value !== undefined && value.trim().length > 0;
+
+// RFC 2426 §5.8.4: backslash must be escaped first, then the other
+// reserved characters, or the later escapes would themselves get escaped.
+const escapeText = (value: string): string =>
+  value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\r\n|\r|\n/g, "\\n");
+
+const buildFullName = (firstName: string, lastName: string): string =>
+  [firstName, lastName]
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .join(" ");
+
+export const buildVCard = (data: BusinessCardData): string => {
+  const firstName = data.firstName.trim();
+  const lastName = data.lastName.trim();
+
+  const organization = escapeText(data.organization.trim());
+  const orgLine = hasValue(data.department)
+    ? `ORG:${organization};${escapeText(data.department.trim())}`
+    : `ORG:${organization}`;
+
+  const lines = [
+    "BEGIN:VCARD",
+    "VERSION:3.0",
+    `N:${escapeText(lastName)};${escapeText(firstName)};;;`,
+    `FN:${escapeText(buildFullName(firstName, lastName))}`,
+    orgLine,
+  ];
+
+  if (hasValue(data.jobTitle)) {
+    lines.push(`TITLE:${escapeText(data.jobTitle.trim())}`);
+  }
+
+  lines.push(`EMAIL;TYPE=INTERNET,WORK:${escapeText(data.workEmail.trim())}`);
+
+  if (hasValue(data.workPhone)) {
+    lines.push(`TEL;TYPE=WORK,VOICE:${escapeText(data.workPhone.trim())}`);
+  }
+
+  if (hasValue(data.mobile)) {
+    lines.push(`TEL;TYPE=CELL,VOICE:${escapeText(data.mobile.trim())}`);
+  }
+
+  lines.push(`URL:${escapeText(data.website.trim())}`);
+
+  if (hasValue(data.address)) {
+    lines.push(`ADR;TYPE=WORK:;;${escapeText(data.address.trim())};;;;`);
+  }
+
+  lines.push("END:VCARD");
+
+  return lines.join(CRLF) + CRLF;
+};
+
+const UNSAFE_FILENAME_CHARS = /[/\\:*?"<>|\s]+/g;
+
+export const vCardFileName = (data: BusinessCardData): string => {
+  const fullName = buildFullName(data.firstName, data.lastName);
+
+  const safeName = fullName
+    .replace(UNSAFE_FILENAME_CHARS, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return safeName.length > 0 ? `${safeName}.vcf` : "contact.vcf";
+};


### PR DESCRIPTION
## What

Adds the data layer behind the digital business card. No UI and no wiring into a screen — that lands in the PR stacked on top of this one.

- **`utils/vcard.ts`** — builds an RFC 2426 vCard. Escaping runs backslash → semicolon → comma → newlines, in that order, so later escapes don't re-escape earlier ones. Absent optional fields are omitted rather than emitted empty, which is what keeps a mobile number off a card that hasn't got one.
- **`utils/businessCard.ts`** — merges the directory `/user-info` response with the access token claims: directory first, the claim fills the gap. `jobtitle`, `phone_number` and `profile` exist only in the token today.
- **`utils/tokenClaims.ts` + `hooks/useTokenClaims.ts`** — decode and merge claims field by field across the access and ID tokens. Asgardeo puts a given claim in whichever token the OIDC app's claim config names, and that differs per app and can move between releases, so picking one token wholesale isn't safe.

Adds three optional claims to `DecodedAccessToken`: `jobtitle`, `phone_number`, `profile`. These keep Asgardeo's own spellings (not camelCase) because they're looked up by the exact key the token carries.

## Testing

93 tests across 6 suites, all passing.

The vCard encoder is specified by `utils/__tests__/vcard_cases.json` — a fixture shared with the wallet pass service's Go encoder, so the QR on a pass and the QR in the app scan to the same contact. Expected values are hand-derived from the RFC, never regenerated from an implementation, since a regenerated fixture would just agree with a bug. Coverage includes escape ordering, CRLF/CR/LF collapsing, whitespace-only optionals, empty name parts, and Sinhala/Tamil/accented-Latin names.

## Notes for review

- All changes are under `frontend/`.
- No behaviour change ships in this PR — nothing imports these modules yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added business card data support, including contact details, job information, organization, website, phone numbers, and profile photos.
  * Added vCard 3.0 generation with contact fields, address support, character escaping, and sanitized filenames.
  * Added reliable profile-claim handling across available sign-in tokens and secure storage.
* **Bug Fixes**
  * Improved handling of missing, blank, or opaque authentication tokens.
* **Tests**
  * Added comprehensive coverage for business card conversion, profile claims, photo URLs, and vCard output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->