### PR TITLE
[Backend] Feature: Surface business-card claims from the access token

### DIFF
--- a/backend/modules/authorization/authorization.bal
+++ b/backend/modules/authorization/authorization.bal
@@ -52,10 +52,28 @@ public isolated service class JwtInterceptor {
         CustomJwtPayload customUserInfo = {
             userId: userInfo.userid,
             email: userInfo.email,
-            groups: userInfo.groups ?: []
+            groups: userInfo.groups ?: [],
+            firstName: optionalStringClaim(userInfo, CLAIM_GIVEN_NAME),
+            lastName: optionalStringClaim(userInfo, CLAIM_FAMILY_NAME),
+            jobTitle: optionalStringClaim(userInfo, CLAIM_JOB_TITLE),
+            mobile: optionalStringClaim(userInfo, CLAIM_PHONE_NUMBER),
+            profileUrl: optionalStringClaim(userInfo, CLAIM_PROFILE)
         };
 
         ctx.set(HEADER_USER_INFO, customUserInfo);
         return ctx.next();
     }
+}
+
+# Reads an optional string claim from the decoded JWT payload.
+#
+# The business-card claims are cosmetic, so a claim that is absent or carries an unexpected
+# shape yields nil rather than failing the request.
+#
+# + payload - Decoded JWT payload
+# + claim - Name of the claim to read
+# + return - The claim value, or nil if it is absent or not a string
+isolated function optionalStringClaim(JwtPayload payload, string claim) returns string? {
+    json value = payload[claim];
+    return value is string ? value : ();
 }

--- a/backend/modules/authorization/constants.bal
+++ b/backend/modules/authorization/constants.bal
@@ -17,3 +17,10 @@
 # Authorization Constants.
 public const JWT_ASSERTION_HEADER = "x-jwt-assertion";
 public const HEADER_USER_INFO = "user-info";
+
+# Business card claims carried by the access token.
+const CLAIM_GIVEN_NAME = "given_name";
+const CLAIM_FAMILY_NAME = "family_name";
+const CLAIM_JOB_TITLE = "jobtitle";
+const CLAIM_PHONE_NUMBER = "phone_number";
+const CLAIM_PROFILE = "profile";

--- a/backend/modules/authorization/types.bal
+++ b/backend/modules/authorization/types.bal
@@ -27,6 +27,16 @@ public type CustomJwtPayload record {|
     *BaseJwtPayload;
     # User ID
     string userId;
+    # First name of the user
+    string? firstName;
+    # Last name of the user
+    string? lastName;
+    # Job title of the user
+    string? jobTitle;
+    # Mobile phone number of the user
+    string? mobile;
+    # Profile picture URL of the user
+    string? profileUrl;
 |};
 
 # JWT payload record.
@@ -34,5 +44,9 @@ public type JwtPayload record {|
     *BaseJwtPayload;
     # User ID
     string userid;
+    // The business-card claims (`given_name`, `family_name`, `jobtitle`, `phone_number`,
+    // `profile`) arrive through this rest field and are read with `optionalStringClaim`.
+    // Declaring them as typed fields would make `cloneWithType` — and so every authenticated
+    // request — fail if the IdP ever emitted one with an unexpected shape.
     json...;
 |};


### PR DESCRIPTION
> **This PR was rewritten.** It previously added HR GraphQL and SCIM lookups for business-card data. Following the [restructure plan](https://github.com/opensuperapp/opensuperapp/pull/75), the card is derived entirely from access-token claims, so no directory lookup is needed at all. The entire previous diff is gone; `modules/entity` and `modules/scim` are now byte-identical to `v1`.

### What this does

Every field the business card renders is already a claim on the Asgardeo access token:

| Card field | Claim |
|---|---|
| `userId` | `userid` |
| `workEmail` | `email` (also `sub`) |
| `firstName` | `given_name` |
| `lastName` | `family_name` |
| `jobTitle` | `jobtitle` |
| `mobile` | `phone_number` |
| photo | `profile` |

`authorization:CustomJwtPayload` surfaced only `userId`, `email` and `groups`. The other claims already arrived — `JwtPayload` carries a `json...` rest field — they were simply never extracted into the request context. This PR extracts them.

### Why the claims aren't declared as typed fields

They're read off the rest field via `optionalStringClaim` rather than declared as `string given_name?` on `JwtPayload`. Declaring them would narrow what `cloneWithType` accepts: if the IdP ever emitted one of them as a number or an array, the clone would fail and **every authenticated request** would 500 with "Malformed Invoker info object!". These claims are cosmetic — a missing job title should cost a job title, not the whole API. So an absent or unexpectedly-shaped claim yields nil.

### Scope

Only `backend/modules/authorization/`. Nothing consumes the new fields yet — that's #74.

`bal build` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access tokens now support optional business-card details, including name, job title, mobile number, and profile URL.
  * These details are safely included when valid string values are provided, without disrupting authorization when claims are missing or malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->