### PR TITLE
[Backend] Feature: Derive the business card from access-token claims

### DIFF
--- a/backend/types.bal
+++ b/backend/types.bal
@@ -15,6 +15,24 @@
 // under the License.
 import superapp_mobile_service.database;
 
+# Business card field set for an employee.
+public type BusinessCard record {|
+    # User id of the employee
+    string userId;
+    # First name of the employee
+    string firstName;
+    # Last name of the employee
+    string lastName;
+    # Work email of the employee
+    string workEmail;
+    # Job title of the employee
+    string? jobTitle;
+    # Mobile phone number of the employee
+    string? mobile;
+    # Profile picture URL of the employee
+    string? thumbnailUrl;
+|};
+
 # App scope record type.
 public type MicroAppScope record {|
     # Micro-app id

--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import superapp_mobile_service.authorization;
 import superapp_mobile_service.entity;
 
 import ballerina/cache;
@@ -43,4 +44,34 @@ public isolated function getUserInfo(string email) returns entity:Employee|error
     }
 
     return employee;
+}
+
+# Builds the business card of the logged in user from the access token claims.
+#
+# + userInfo - Claims of the caller, extracted from the access token by the JWT interceptor
+# + return - BusinessCard of the caller
+public isolated function toBusinessCard(authorization:CustomJwtPayload userInfo) returns BusinessCard => {
+    userId: userInfo.userId,
+    // The wallet pass contract requires non-null names, so an absent claim becomes an empty string.
+    firstName: userInfo.firstName ?: "",
+    lastName: userInfo.lastName ?: "",
+    workEmail: userInfo.email,
+    jobTitle: userInfo.jobTitle,
+    mobile: userInfo.mobile,
+    thumbnailUrl: toFullResolutionPhotoUrl(userInfo.profileUrl)
+};
+
+# Strips the size suffix from a profile picture URL.
+#
+# The `profile` claim carries a Google photo URL sized down by a trailing `=s<pixels>` suffix
+# (`https://lh3.googleusercontent.com/a/XXXX=s100`). Dropping the suffix yields the full
+# resolution image, which is what a wallet pass renders. URLs without the suffix are left as is.
+#
+# + url - Profile picture URL from the `profile` claim, if any
+# + return - Full resolution URL, or nil when there is no usable URL
+isolated function toFullResolutionPhotoUrl(string? url) returns string? {
+    if url is () || url.trim() == "" {
+        return ();
+    }
+    return re `=s\d+$`.replace(url, "");
 }


### PR DESCRIPTION
> **This PR was rewritten.** It previously added a `GET /business-card/card-data` endpoint backed by an HR GraphQL round-trip and a cache. Both are gone.

### Why there's no endpoint any more

The endpoint would have built the card from `ctx` claims in-process and returned it to an app that already does exactly this — `frontend/utils/businessCard.ts:toBusinessCardData` derives the same values from the same token. A server endpoint that re-derives them earns nothing, so it isn't here.

`businessCardInfoCache` and `getBusinessCardInfo` are gone with it: there is no HR round-trip left to cache.

### What's left

The two pieces the wallet proxy in #75 actually consumes:

- `BusinessCard` — the card field set. `department` and `location` are out of scope for now, and `workPhone` was always hardcoded nil, so none of the three appear.
- `toBusinessCard(authorization:CustomJwtPayload)` — maps the claims surfaced in #73 onto that record.

One wrinkle worth a look: the `profile` claim is a Google photo URL sized down by a trailing `=s100` suffix. `toFullResolutionPhotoUrl` strips it so the wallet pass renders the full-resolution image, and returns nil rather than `""` for a blank claim.

`firstName`/`lastName` fall back to `""` because the wallet contract requires non-null names.

Stacked on #73. `bal build` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added business card data support, including names, work email, job title, mobile number, and profile photo.
  * Profile photos can now be retrieved at full resolution when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->