### PR TITLE
[Backend] Feature: Proxy wallet-pass requests to the wallet service

### DIFF
--- a/backend/Dependencies.toml
+++ b/backend/Dependencies.toml
@@ -487,6 +487,7 @@ modules = [
 	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.authorization"},
 	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.database"},
 	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.entity"},
-	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.scim"}
+	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.scim"},
+	{org = "opensuperapp", packageName = "superapp_mobile_service", moduleName = "superapp_mobile_service.wallet"}
 ]
 

--- a/backend/config.toml.local
+++ b/backend/config.toml.local
@@ -38,4 +38,7 @@ scimUrl=""
     clientId=""
     clientSecret=""
     scopes=[""]
+
+[superapp_mobile_service.wallet]
+walletServiceBaseUrl=""
     

--- a/backend/modules/wallet/client.bal
+++ b/backend/modules/wallet/client.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import ballerina/http;
+
+configurable string walletServiceBaseUrl = ?;
+
+// No `auth` configuration: the wallet service accepts the caller's own `x-jwt-assertion`,
+// which is forwarded per request, so this client needs no credentials of its own.
+final http:Client walletClient = check new (walletServiceBaseUrl, {
+    httpVersion: http:HTTP_1_1,
+    http1Settings: {keepAlive: http:KEEPALIVE_NEVER}
+});

--- a/backend/modules/wallet/constants.bal
+++ b/backend/modules/wallet/constants.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Wallet service path that builds a signed Apple Wallet pass
+const APPLE_PASS_PATH = "/api/v1/business-card/pkpass";
+
+# Wallet service path that builds a Google Wallet save URL
+const GOOGLE_SAVE_URL_PATH = "/api/v1/business-card/google-save-url";

--- a/backend/modules/wallet/types.bal
+++ b/backend/modules/wallet/types.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Business card payload sent to the wallet service.
+#
+# The wallet service keys a pass by `serialNumber`, which is the user id under a different
+# name. That rename is the reason this record exists rather than posting a `BusinessCard`
+# directly. Fields the card does not carry (`department`, `workPhone`, `organization`,
+# `website`, `address`) are simply not sent; the wallet service treats them as absent.
+public type WalletCardRequest record {|
+    # User id of the employee, the serial number of the pass
+    string serialNumber;
+    # First name of the employee
+    string firstName;
+    # Last name of the employee
+    string lastName;
+    # Work email of the employee
+    string workEmail;
+    # Job title of the employee
+    string jobTitle?;
+    # Mobile phone number of the employee
+    string mobile?;
+    # Profile picture URL of the employee, rendered on the pass
+    string employeeThumbnail?;
+|};
+
+# Google Wallet save URL returned by the wallet service.
+public type GoogleSaveUrl record {|
+    # URL that adds the pass to the user's Google Wallet
+    string saveUrl;
+|};

--- a/backend/modules/wallet/wallet.bal
+++ b/backend/modules/wallet/wallet.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import superapp_mobile_service.authorization;
+
+# Builds a signed Apple Wallet pass for the given business card.
+#
+# + card - Business card fields to render on the pass
+# + jwtAssertion - JWT assertion of the caller, forwarded to the wallet service
+# + return - The `.pkpass` bytes, or an error if the operation fails
+public isolated function getApplePass(WalletCardRequest card, string jwtAssertion) returns byte[]|error {
+    byte[] pass = check walletClient->post(APPLE_PASS_PATH, card, {[authorization:JWT_ASSERTION_HEADER]: jwtAssertion});
+    return pass;
+}
+
+# Builds a Google Wallet save URL for the given business card.
+#
+# + card - Business card fields to render on the pass
+# + jwtAssertion - JWT assertion of the caller, forwarded to the wallet service
+# + return - The Google Wallet save URL, or an error if the operation fails
+public isolated function getGoogleSaveUrl(WalletCardRequest card, string jwtAssertion) returns GoogleSaveUrl|error {
+    GoogleSaveUrl saveUrl = check walletClient->post(GOOGLE_SAVE_URL_PATH, card,
+            {[authorization:JWT_ASSERTION_HEADER]: jwtAssertion});
+    return saveUrl;
+}

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -18,6 +18,7 @@ import superapp_mobile_service.authorization;
 import superapp_mobile_service.database;
 import superapp_mobile_service.entity;
 import superapp_mobile_service.scim;
+import superapp_mobile_service.wallet;
 
 import ballerina/http;
 import ballerina/log;
@@ -145,6 +146,95 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
         }
 
         return loggedInUser;
+    }
+
+    # Build the Apple Wallet business card pass of the logged in user.
+    #
+    # + ctx - Request context
+    # + req - HTTP request, used to forward the caller's JWT assertion to the wallet service
+    # + return - The `.pkpass` bytes, or an `http:InternalServerError` if the operation fails
+    resource function get business\-card/pkpass(http:RequestContext ctx, http:Request req)
+        returns http:Response|http:InternalServerError {
+
+        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        string|error jwtAssertion = req.getHeader(authorization:JWT_ASSERTION_HEADER);
+        if jwtAssertion is error {
+            string customError = "Missing invoker info header!";
+            log:printError(customError, jwtAssertion);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        byte[]|error pass = wallet:getApplePass(toWalletCardRequest(toBusinessCard(userInfo)), jwtAssertion);
+        if pass is error {
+            string customError = "Error occurred while generating the Apple Wallet pass!";
+            log:printError(customError, pass);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        http:Response response = new;
+        response.setBinaryPayload(pass, "application/vnd.apple.pkpass");
+        response.setHeader("Content-Disposition", string `attachment; filename="wso2-business-card.pkpass"`);
+        response.setHeader("Cache-Control", "no-store");
+        return response;
+    }
+
+    # Build the Google Wallet save URL for the business card of the logged in user.
+    #
+    # + ctx - Request context
+    # + req - HTTP request, used to forward the caller's JWT assertion to the wallet service
+    # + return - The Google Wallet save URL, or an `http:InternalServerError` if the operation fails
+    resource function get business\-card/google\-save\-url(http:RequestContext ctx, http:Request req)
+        returns wallet:GoogleSaveUrl|http:InternalServerError {
+
+        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
+        if userInfo is error {
+            return <http:InternalServerError>{
+                body: {
+                    message: ERR_MSG_USER_HEADER_NOT_FOUND
+                }
+            };
+        }
+
+        string|error jwtAssertion = req.getHeader(authorization:JWT_ASSERTION_HEADER);
+        if jwtAssertion is error {
+            string customError = "Missing invoker info header!";
+            log:printError(customError, jwtAssertion);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        wallet:GoogleSaveUrl|error saveUrl = wallet:getGoogleSaveUrl(toWalletCardRequest(toBusinessCard(userInfo)),
+                jwtAssertion);
+        if saveUrl is error {
+            string customError = "Error occurred while generating the Google Wallet save URL!";
+            log:printError(customError, saveUrl);
+            return <http:InternalServerError>{
+                body: {
+                    message: customError
+                }
+            };
+        }
+
+        return saveUrl;
     }
 
     # Retrieves the list of micro apps available to the authenticated user.

--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -15,6 +15,7 @@
 // under the License.
 import superapp_mobile_service.authorization;
 import superapp_mobile_service.entity;
+import superapp_mobile_service.wallet;
 
 import ballerina/cache;
 import ballerina/log;
@@ -74,4 +75,34 @@ isolated function toFullResolutionPhotoUrl(string? url) returns string? {
         return ();
     }
     return re `=s\d+$`.replace(url, "");
+}
+
+# Maps a business card to the payload the wallet service expects.
+#
+# + card - Business card of the user
+# + return - wallet:WalletCardRequest to POST to the wallet service
+isolated function toWalletCardRequest(BusinessCard card) returns wallet:WalletCardRequest {
+    wallet:WalletCardRequest cardRequest = {
+        serialNumber: card.userId,
+        firstName: card.firstName,
+        lastName: card.lastName,
+        workEmail: card.workEmail
+    };
+
+    string? jobTitle = card.jobTitle;
+    if jobTitle is string {
+        cardRequest.jobTitle = jobTitle;
+    }
+
+    string? mobile = card.mobile;
+    if mobile is string {
+        cardRequest.mobile = mobile;
+    }
+
+    string? thumbnailUrl = card.thumbnailUrl;
+    if thumbnailUrl is string {
+        cardRequest.employeeThumbnail = thumbnailUrl;
+    }
+
+    return cardRequest;
 }


### PR DESCRIPTION
> **This PR was rewritten and now inverts completely.** It previously added `backend/business_card_internal.bal` — an uninterceptable second service on an extracted shared listener — so the Go wallet-service could *pull* card data back out of Ballerina. Both that file and the `mainListener` extraction are gone; `service.bal`'s listener reverts to the inline anonymous one.

## The inversion

```
app ──────────────► ballerina ──────────────► wallet-service
                        │                          │
                        └──► HR GraphQL / SCIM     └──► APNs / Google Wallet API
```

Card data is **pushed** to the wallet-service, never pulled from it. Nothing calls *into* Ballerina from the wallet-service any more.

### Why the second service existed, and why it doesn't need to

`authorization:JwtInterceptor` hard-requires `x-jwt-assertion` on *every* path (`default [string... path]`). A wallet-service calling in has no user session, so it could not go through the main service — hence a second, uninterceptable service sharing the listener. That was the whole reason for the file.

Invert the direction and the reason disappears. Both new resources live **inside** the main interceptable service, so they get `JwtInterceptor` and `userInfo` for free.

## What's added

- `backend/modules/wallet/` — an HTTP client to the wallet-service behind a new `walletServiceBaseUrl` configurable. No `auth` config of its own: the caller's `x-jwt-assertion` is forwarded per request, so the wallet-service's existing auth is unchanged for the user-initiated path.
- `GET /business-card/pkpass` — resolves the card in-process, POSTs it, streams the bytes back as `application/vnd.apple.pkpass`.
- `GET /business-card/google-save-url` — same, forwarding the `saveUrl` JSON.

### `WalletCardRequest` and the `serialNumber` rename

The wallet-service keys a pass by `serialNumber`, which is the user id under a different name. That rename is why `WalletCardRequest` exists rather than posting a `BusinessCard` directly — and it closes a latent gap, since the Go side's `Card.SerialNumber` never actually populated from the wire and was always stamped by the caller.

## ⚠️ Requires a matching wallet-service change

**This will not work end-to-end until the Go side lands.** The two pass endpoints currently resolve card data themselves via `internal/carddata`; under this contract they take card fields in a **POST body** instead. The Go service also drops `internal/carddata`, its OAuth2 client-credentials token source, and `x-jwt-assertion` forwarding — it stops knowing the Ballerina backend exists.

That change is deliberately out of scope here (the wallet-service isn't on `v1` yet). Nothing ships broken in the meantime: the app's wallet action is gated behind `EXPO_PUBLIC_ENABLE_WALLET_PASS` plus remote config.

## Not included

The nightly refresh push job. It's gated on an unverified question — whether Asgardeo SCIM can serve `jobtitle` and `profile` as requestable attributes, since they're custom claims rather than OIDC standard ones. Without a tokenless data source the job has nothing to push, so it isn't built and the SCIM half of #73 was deleted rather than reshaped. Installed passes are static until that's resolved.

Stacked on #74. `bal build` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Wallet support for generating and downloading digital business cards.
  * Added Google Wallet support for generating save URLs for digital business cards.
  * Business card details, including optional contact information and profile images, are included when available.
  * Added authenticated wallet service integration for secure pass generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->