### PR TITLE
[Frontend] Chore: Route wallet pass requests through the backend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,12 +4,11 @@ EXPO_PUBLIC_TOKEN_URL=https://api.asgardeo.io/t/<asgardeo-organization>/oauth2/t
 EXPO_PUBLIC_LOGOUT_URL=https://api.asgardeo.io/t/<asgardeo-organization>/oidc/logout
 EXPO_PUBLIC_BACKEND_BASE_URL=<backend-url>         # Backend API Base URL
 EXPO_PUBLIC_CHAT_AGENT_URL=<chat-agent-url>        # Chat agent API base URL (e.g. http://localhost:8000)
-EXPO_PUBLIC_WALLET_SERVICE_BASE_URL=<wallet-pass-service-url> # Wallet pass service base URL (separate backend, see wallet-pass-service)
 
 # Build-time switch for the "Save Business Card" wallet pass feature.
-# Set to "true" only if you have a wallet-pass-service deployment to point
-# EXPO_PUBLIC_WALLET_SERVICE_BASE_URL at. Left unset/false, the wallet action is
-# disabled in the app and no request is ever made.
+# The pass is served by the backend at EXPO_PUBLIC_BACKEND_BASE_URL, so there is
+# no separate URL to set. Left unset/false, the wallet action is disabled in the
+# app and no request is ever made.
 # Per-OS rollout on top of this is done with Firebase Remote Config (see below).
 EXPO_PUBLIC_ENABLE_WALLET_PASS=<true/false>
 
@@ -108,7 +107,7 @@ EXPO_PUBLIC_ENABLE_FIREBASE=<true/false>
 #   Per OS because the Apple .pkpass path and the Google save-link path depend on separate
 #   certificates and separate console onboarding, so either has to be switchable alone.
 # - Defaults to both off (see frontend/config/remoteConfig.ts), so the action is disabled and
-#   no wallet-pass-service request is made until explicitly turned on.
+#   no wallet pass request is made to the backend until explicitly turned on.
 # - EXPO_PUBLIC_ENABLE_WALLET_PASS must also be true; the env flag is the build-time switch
 #   and this is the runtime rollout. Either one off means off.
 #

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -292,7 +292,7 @@ Paste the generated strings into the `FIREBASE_IOS_PLIST_B64` and `FIREBASE_ANDR
 EXPO_PUBLIC_ENABLE_WALLET_PASS=true
 ```
 
-This is the build-time switch for the "Save Business Card" action that adds the card to Apple Wallet or Google Wallet. It needs a wallet-pass-service deployment behind `EXPO_PUBLIC_WALLET_SERVICE_BASE_URL`; left unset, the action is disabled and the app never calls the service.
+This is the build-time switch for the "Save Business Card" action that adds the card to Apple Wallet or Google Wallet. The pass is served by the backend at `EXPO_PUBLIC_BACKEND_BASE_URL`, so no other URL is involved; left unset, the action is disabled and the app never asks the backend for a pass.
 
 Rollout per operating system is done with Firebase Remote Config, so either platform can be turned on (or pulled) without a release. Create a single JSON parameter named `wallet_pass_enabled` in **Firebase Console > Remote Config**:
 

--- a/frontend/constants/Constants.ts
+++ b/frontend/constants/Constants.ts
@@ -26,13 +26,6 @@ export const REDIRECT_URI = process.env.EXPO_PUBLIC_REDIRECT_URI ?? "";
 export const TOKEN_URL = process.env.EXPO_PUBLIC_TOKEN_URL ?? "";
 export const LOGOUT_URL = process.env.EXPO_PUBLIC_LOGOUT_URL ?? "";
 export const BASE_URL = process.env.EXPO_PUBLIC_BACKEND_BASE_URL ?? "";
-// The wallet pass service is a separate backend from BASE_URL.
-export const WALLET_SERVICE_BASE_URL =
-  process.env.EXPO_PUBLIC_WALLET_SERVICE_BASE_URL ?? "";
-// Unset, the wallet endpoints stay relative paths that axios in React Native
-// cannot resolve, so treat the feature as unconfigured rather than broken.
-export const IS_WALLET_SERVICE_CONFIGURED =
-  WALLET_SERVICE_BASE_URL.trim() !== "";
 export const MICRO_APP_STORAGE_DIR =
   process.env.EXPO_PUBLIC_MICRO_APP_STORAGE_DIR ?? "";
 export const ARTICLE_BASE_URL = process.env.EXPO_PUBLIC_ARTICLE_BASE_URL ?? "";

--- a/frontend/hooks/__tests__/useWalletPassEnabled.test.tsx
+++ b/frontend/hooks/__tests__/useWalletPassEnabled.test.tsx
@@ -44,24 +44,21 @@ const renderHook = (): boolean => {
 };
 
 /**
- * Loads the hook with the env flag, the service base URL and the platform set,
- * and the remote config hook handing back `config` verbatim — including shapes
- * Firebase could actually serve if someone edits the JSON badly.
+ * Loads the hook with the env flag and the platform set, and the remote config
+ * hook handing back `config` verbatim — including shapes Firebase could
+ * actually serve if someone edits the JSON badly.
  */
 const setup = ({
   envEnabled,
   platform,
   config,
-  serviceBaseUrl = "https://wallet.example.com",
 }: {
   envEnabled: boolean;
   platform: "ios" | "android";
   config: unknown;
-  serviceBaseUrl?: string;
 }) => {
   jest.resetModules();
   process.env.EXPO_PUBLIC_ENABLE_WALLET_PASS = envEnabled ? "true" : "false";
-  process.env.EXPO_PUBLIC_WALLET_SERVICE_BASE_URL = serviceBaseUrl;
 
   jest.doMock("react-native", () => ({ Platform: { OS: platform } }));
 
@@ -75,11 +72,9 @@ const setup = ({
 
 describe("useWalletPassEnabled", () => {
   const originalEnv = process.env.EXPO_PUBLIC_ENABLE_WALLET_PASS;
-  const originalBaseUrl = process.env.EXPO_PUBLIC_WALLET_SERVICE_BASE_URL;
 
   afterAll(() => {
     process.env.EXPO_PUBLIC_ENABLE_WALLET_PASS = originalEnv;
-    process.env.EXPO_PUBLIC_WALLET_SERVICE_BASE_URL = originalBaseUrl;
   });
 
   it("is enabled on iOS when the env flag and the config's ios field are both on", () => {
@@ -133,20 +128,6 @@ describe("useWalletPassEnabled", () => {
       envEnabled: false,
       platform: "ios",
       config: { ios: true, android: true },
-    });
-
-    expect(renderHook()).toBe(false);
-  });
-
-  // The failure this gate exists for: everything switched on, but the URL the
-  // service would call never made it into .env, so the button would only fire
-  // a request axios reports as a bare "Network Error".
-  it("stays off when there is no wallet service base URL to call", () => {
-    setup({
-      envEnabled: true,
-      platform: "ios",
-      config: { ios: true, android: true },
-      serviceBaseUrl: "",
     });
 
     expect(renderHook()).toBe(false);

--- a/frontend/hooks/useWalletPassEnabled.ts
+++ b/frontend/hooks/useWalletPassEnabled.ts
@@ -13,10 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import {
-  ENABLE_WALLET_PASS,
-  IS_WALLET_SERVICE_CONFIGURED,
-} from "@/constants/Constants";
+import { ENABLE_WALLET_PASS } from "@/constants/Constants";
 import { WALLET_PASS_ENABLED_KEY } from "@/constants/RemoteConfigDefaults";
 import { useRemoteConfig } from "@/hooks/useRemoteConfig";
 import {
@@ -25,8 +22,8 @@ import {
 } from "@/types/remoteConfig.types";
 import { Platform } from "react-native";
 
-// Three independent gates: the build ships the feature at all, a service URL
-// exists to call, and WSO2 has it switched on for this OS right now.
+// Two independent gates: the build ships the feature at all, and WSO2 has it
+// switched on for this OS right now.
 export const useWalletPassEnabled = (): boolean => {
   const { value: config } = useRemoteConfig<WalletPassConfig>(
     WALLET_PASS_ENABLED_KEY,
@@ -35,9 +32,5 @@ export const useWalletPassEnabled = (): boolean => {
 
   // `=== true`, not truthiness: the config comes from JSON.parse, so `null` or
   // a stringly-typed "true" have to read as off rather than pass or crash.
-  return (
-    ENABLE_WALLET_PASS &&
-    IS_WALLET_SERVICE_CONFIGURED &&
-    config?.[Platform.OS] === true
-  );
+  return ENABLE_WALLET_PASS && config?.[Platform.OS] === true;
 };

--- a/frontend/services/__tests__/walletPassService.nativePass.test.ts
+++ b/frontend/services/__tests__/walletPassService.nativePass.test.ts
@@ -22,14 +22,12 @@ jest.mock("@/utils/requestHandler", () => ({
   apiRequest: jest.fn(),
 }));
 
-// The endpoint URLs are built when the service loads, and the service refuses
-// to request against an empty base URL, so pin one rather than depend on the
-// environment running the tests.
+// The endpoint URLs are built when the service loads, so pin the base URL
+// rather than depend on the environment running the tests.
 jest.mock("@/constants/Constants", () => ({
   __esModule: true,
   ...jest.requireActual("@/constants/Constants"),
-  WALLET_SERVICE_BASE_URL: "https://wallet.example.com",
-  IS_WALLET_SERVICE_CONFIGURED: true,
+  BASE_URL: "https://backend.example.com",
 }));
 
 jest.mock("expo-sharing", () => ({

--- a/frontend/services/__tests__/walletPassService.test.ts
+++ b/frontend/services/__tests__/walletPassService.test.ts
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import * as Constants from "@/constants/Constants";
 import {
   addToAppleWallet,
   addToGoogleWallet,
@@ -27,15 +26,12 @@ jest.mock("@/utils/requestHandler", () => ({
 }));
 
 // The endpoint URLs are built when the service loads, so the base URL is
-// pinned here instead of being whatever EXPO_PUBLIC_WALLET_SERVICE_BASE_URL
-// happens to be in the shell running the tests. `__esModule` keeps this the
-// one module object both the service and the unconfigured suite below hold,
-// which is what lets that suite flip the flag with jest.replaceProperty.
+// pinned here instead of being whatever EXPO_PUBLIC_BACKEND_BASE_URL happens
+// to be in the shell running the tests.
 jest.mock("@/constants/Constants", () => ({
   __esModule: true,
   ...jest.requireActual("@/constants/Constants"),
-  WALLET_SERVICE_BASE_URL: "https://wallet.example.com",
-  IS_WALLET_SERVICE_CONFIGURED: true,
+  BASE_URL: "https://backend.example.com",
 }));
 
 jest.mock("expo-sharing", () => ({
@@ -112,7 +108,7 @@ describe("addToAppleWallet", () => {
 
     expect(apiRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.stringContaining("/api/v1/business-card/pkpass"),
+        url: "https://backend.example.com/business-card/pkpass",
         method: "GET",
         responseType: "arraybuffer",
       }),
@@ -181,7 +177,7 @@ describe("addToGoogleWallet", () => {
 
     expect(apiRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.stringContaining("/api/v1/business-card/google-save-url"),
+        url: "https://backend.example.com/business-card/google-save-url",
         method: "GET",
       }),
       onLogout
@@ -218,44 +214,5 @@ describe("addToGoogleWallet", () => {
 
     await expect(addToGoogleWallet(true, onLogout)).resolves.toBe(false);
     expect(Alert.alert).toHaveBeenCalled();
-  });
-});
-
-/**
- * The build this guard exists for: EXPO_PUBLIC_WALLET_SERVICE_BASE_URL never
- * made it into .env, so the endpoint URLs are relative paths that axios in
- * React Native cannot resolve. useWalletPassEnabled already hides the button
- * in that build, but the service has to hold the line on its own — otherwise
- * any other caller gets a bare "AxiosError: Network Error" that names nothing.
- */
-describe("with no wallet service base URL configured", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.replaceProperty(Constants, "IS_WALLET_SERVICE_CONFIGURED", false);
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it("keeps addToAppleWallet from requesting, and names the missing variable", async () => {
-    await expect(addToAppleWallet(true, onLogout)).resolves.toBe(false);
-
-    expect(apiRequest).not.toHaveBeenCalled();
-    expect(Sharing.shareAsync).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("EXPO_PUBLIC_WALLET_SERVICE_BASE_URL")
-    );
-  });
-
-  it("keeps addToGoogleWallet from requesting, and names the missing variable", async () => {
-    await expect(addToGoogleWallet(true, onLogout)).resolves.toBe(false);
-
-    expect(apiRequest).not.toHaveBeenCalled();
-    expect(Linking.openURL).not.toHaveBeenCalled();
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining("EXPO_PUBLIC_WALLET_SERVICE_BASE_URL")
-    );
   });
 });

--- a/frontend/services/walletPassService.ts
+++ b/frontend/services/walletPassService.ts
@@ -13,18 +13,14 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import {
-  IS_WALLET_SERVICE_CONFIGURED,
-  isIos,
-  WALLET_SERVICE_BASE_URL,
-} from "@/constants/Constants";
+import { BASE_URL, isIos } from "@/constants/Constants";
 import { presentApplePass } from "@/services/wallet/applePassPresenter";
 import { apiRequest } from "@/utils/requestHandler";
 import { File, Paths } from "expo-file-system";
 import { Alert, Linking } from "react-native";
 
-const PKPASS_URL = `${WALLET_SERVICE_BASE_URL}/api/v1/business-card/pkpass`;
-const GOOGLE_SAVE_URL_ENDPOINT = `${WALLET_SERVICE_BASE_URL}/api/v1/business-card/google-save-url`;
+const PKPASS_URL = `${BASE_URL}/business-card/pkpass`;
+const GOOGLE_SAVE_URL_ENDPOINT = `${BASE_URL}/business-card/google-save-url`;
 
 type GoogleSaveUrlResponse = {
   saveUrl: string;
@@ -40,24 +36,11 @@ const isSuccessStatus = (status: number | undefined): boolean =>
 const hasPassBytes = (data: unknown): boolean =>
   ((data as ArrayBuffer | undefined)?.byteLength ?? 0) > 0;
 
-// Repeated at the call site so no caller can fire a request that axios cannot
-// resolve, independent of the button-level gate in useWalletPassEnabled.
-const isWalletServiceConfigured = (): boolean => {
-  if (!IS_WALLET_SERVICE_CONFIGURED) {
-    console.warn(
-      "EXPO_PUBLIC_WALLET_SERVICE_BASE_URL is not set; skipping the wallet pass request."
-    );
-    return false;
-  }
-
-  return true;
-};
-
 export const addToAppleWallet = async (
   enabled: boolean,
   onLogout: () => Promise<void>
 ): Promise<boolean> => {
-  if (!enabled || !isWalletServiceConfigured()) {
+  if (!enabled) {
     return false;
   }
 
@@ -100,7 +83,7 @@ export const addToGoogleWallet = async (
   enabled: boolean,
   onLogout: () => Promise<void>
 ): Promise<boolean> => {
-  if (!enabled || !isWalletServiceConfigured()) {
+  if (!enabled) {
     return false;
   }
 


### PR DESCRIPTION
Part of the business-card wallet-pass restructure. The Ballerina backend now mediates all app↔wallet traffic (#75), so the app no longer talks to the wallet-service directly.

### What changes

Both wallet calls move from the separate wallet-service origin to the normal backend base URL:

```
${WALLET_SERVICE_BASE_URL}/api/v1/business-card/pkpass  →  ${BASE_URL}/business-card/pkpass
${WALLET_SERVICE_BASE_URL}/api/v1/business-card/google-save-url  →  ${BASE_URL}/business-card/google-save-url
```

(No `/api/v1` prefix — the Ballerina service is mounted at `/`.) Request and response shapes are unchanged.

Deleted along with it: `EXPO_PUBLIC_WALLET_SERVICE_BASE_URL`, `WALLET_SERVICE_BASE_URL`, `IS_WALLET_SERVICE_CONFIGURED`, and the `isWalletServiceConfigured()` guard in `walletPassService.ts`. With one shared backend URL there's nothing separate left to be unconfigured, so `useWalletPassEnabled` drops from three gates to two — the build flag and the remote config.

**One origin, one failure mode, no second config to drift.**

### Tests

The URL assertions were `expect.stringContaining("/api/v1/business-card/pkpass")`. Simply re-pointing them would have left a matcher that still passes if the old prefix ever came back — the exact regression this PR is about — so they're now exact-equality against the full expected URL.

Three test cases that only covered the removed configured-guard branch are deleted (160 → 157). No suite regressed; `tsc --noEmit` produces the same 13 pre-existing errors as `v1`, none in touched files.

### Merge order

Based on `v1` and independently mergeable, but **the wallet action only works once #75 and the matching wallet-service change land**. It's safe to merge first: the action is gated behind `EXPO_PUBLIC_ENABLE_WALLET_PASS` and remote config.
