### PR TITLE
[Backend] Fix: Authenticate wallet-pass calls with the caller's access token

### DIFF
--- a/backend/config.toml.local
+++ b/backend/config.toml.local
@@ -42,3 +42,5 @@ scimUrl=""
 [superapp_mobile_service.wallet]
 walletServiceBaseUrl=""
     
+[ballerina.log]
+level = ""

--- a/backend/modules/authorization/authorization.bal
+++ b/backend/modules/authorization/authorization.bal
@@ -77,3 +77,43 @@ isolated function optionalStringClaim(JwtPayload payload, string claim) returns 
     json value = payload[claim];
     return value is string ? value : ();
 }
+
+# Reads the caller's access token from the request.
+#
+# Sources are tried in the order they survive an API gateway hop:
+#  1. `x-user-assertion` -- passed through untouched, so it still holds the token the client sent.
+#  2. `Authorization: Bearer` -- present when nothing between the client and this service strips it.
+#  3. `x-jwt-assertion` -- the local development case, where the client sets the raw token here
+#     and no gateway has overwritten it.
+#
+# + req - Incoming HTTP request
+# + return - The access token, or an error when the request carries none
+public isolated function getUserAccessToken(http:Request req) returns string|error {
+    string|error userAssertion = req.getHeader(USER_ASSERTION_HEADER);
+    if userAssertion is string && userAssertion.trim() != "" {
+        log:printDebug("Access token read from the user assertion header", 'source = USER_ASSERTION_HEADER);
+        return userAssertion.trim();
+    }
+
+    string|error authHeader = req.getHeader(AUTHORIZATION_HEADER);
+    if authHeader is string {
+        string trimmed = authHeader.trim();
+        if trimmed.toLowerAscii().startsWith(BEARER_PREFIX.toLowerAscii()) {
+            string token = trimmed.substring(BEARER_PREFIX.length()).trim();
+            if token != "" {
+                log:printDebug("Access token read from the authorization header",
+                        'source = AUTHORIZATION_HEADER);
+                return token;
+            }
+        }
+    }
+
+    string|error assertion = req.getHeader(JWT_ASSERTION_HEADER);
+    if assertion is string && assertion.trim() != "" {
+        log:printDebug("Access token read from the JWT assertion header", 'source = JWT_ASSERTION_HEADER);
+        return assertion.trim();
+    }
+
+    return error("No access token found on the request",
+            checkedHeaders = [USER_ASSERTION_HEADER, AUTHORIZATION_HEADER, JWT_ASSERTION_HEADER]);
+}

--- a/backend/modules/authorization/constants.bal
+++ b/backend/modules/authorization/constants.bal
@@ -16,6 +16,19 @@
 
 # Authorization Constants.
 public const JWT_ASSERTION_HEADER = "x-jwt-assertion";
+
+# Header carrying the caller's raw access token.
+#
+# An API gateway in front of this service overwrites `x-jwt-assertion` with a JWT it mints
+# itself, so that header cannot be replayed against another gateway-fronted API. This one is
+# passed through untouched, which is why the chat agent already uses it for the same purpose.
+public const USER_ASSERTION_HEADER = "x-user-assertion";
+
+# Header carrying the caller's bearer token, used as a fallback source of the access token.
+public const AUTHORIZATION_HEADER = "Authorization";
+
+# Scheme prefix of the `Authorization` header value.
+public const BEARER_PREFIX = "Bearer ";
 public const HEADER_USER_INFO = "user-info";
 
 # Business card claims carried by the access token.

--- a/backend/modules/wallet/client.bal
+++ b/backend/modules/wallet/client.bal
@@ -17,8 +17,9 @@ import ballerina/http;
 
 configurable string walletServiceBaseUrl = ?;
 
-// No `auth` configuration: the wallet service accepts the caller's own `x-jwt-assertion`,
-// which is forwarded per request, so this client needs no credentials of its own.
+// No `auth` configuration: the wallet service authenticates the end user, not this service.
+// It rejects an application (client credentials) token, so the caller's own access token is
+// forwarded per request instead and this client holds no credentials of its own.
 final http:Client walletClient = check new (walletServiceBaseUrl, {
     httpVersion: http:HTTP_1_1,
     http1Settings: {keepAlive: http:KEEPALIVE_NEVER}

--- a/backend/modules/wallet/constants.bal
+++ b/backend/modules/wallet/constants.bal
@@ -19,3 +19,9 @@ const APPLE_PASS_PATH = "/api/v1/business-card/pkpass";
 
 # Wallet service path that builds a Google Wallet save URL
 const GOOGLE_SAVE_URL_PATH = "/api/v1/business-card/google-save-url";
+
+# Header the wallet service authenticates on
+const AUTHORIZATION_HEADER = "Authorization";
+
+# Scheme prefix of the `Authorization` header value
+const BEARER_PREFIX = "Bearer ";

--- a/backend/modules/wallet/types.bal
+++ b/backend/modules/wallet/types.bal
@@ -42,3 +42,16 @@ public type GoogleSaveUrl record {|
     # URL that adds the pass to the user's Google Wallet
     string saveUrl;
 |};
+
+# Failure returned by the wallet service, carrying enough of the upstream response to be
+# actionable in a log line: a bare `error` from the HTTP client hides the status code and
+# body behind a generic message, which is what made the previous 500s undiagnosable.
+public type WalletErrorDetail record {|
+    # HTTP status the wallet service responded with, or `()` when the call never got a response
+    int? statusCode;
+    # Response body of the wallet service, truncated to keep log lines readable
+    string body;
+|};
+
+# Error type raised when the wallet service does not return a pass.
+public type WalletError distinct error<WalletErrorDetail>;

--- a/backend/modules/wallet/wallet.bal
+++ b/backend/modules/wallet/wallet.bal
@@ -15,23 +15,118 @@
 // under the License.
 import superapp_mobile_service.authorization;
 
+import ballerina/http;
+import ballerina/log;
+
+# Longest wallet service error body kept in a log line
+const int MAX_LOGGED_BODY_LENGTH = 512;
+
 # Builds a signed Apple Wallet pass for the given business card.
 #
 # + card - Business card fields to render on the pass
-# + jwtAssertion - JWT assertion of the caller, forwarded to the wallet service
-# + return - The `.pkpass` bytes, or an error if the operation fails
-public isolated function getApplePass(WalletCardRequest card, string jwtAssertion) returns byte[]|error {
-    byte[] pass = check walletClient->post(APPLE_PASS_PATH, card, {[authorization:JWT_ASSERTION_HEADER]: jwtAssertion});
+# + userToken - Access token of the caller, forwarded to the wallet service
+# + return - The `.pkpass` bytes, or a `WalletError` carrying the upstream status and body
+public isolated function getApplePass(WalletCardRequest card, string userToken) returns byte[]|WalletError {
+    http:Response response = check post(APPLE_PASS_PATH, card, userToken);
+    byte[]|error pass = response.getBinaryPayload();
+    if pass is error {
+        return error WalletError("Wallet service returned an unreadable pass payload", pass,
+                statusCode = response.statusCode, body = pass.message());
+    }
+
+    log:printDebug("Wallet service returned an Apple Wallet pass", path = APPLE_PASS_PATH,
+            serialNumber = card.serialNumber, passBytes = pass.length());
     return pass;
 }
 
 # Builds a Google Wallet save URL for the given business card.
 #
 # + card - Business card fields to render on the pass
-# + jwtAssertion - JWT assertion of the caller, forwarded to the wallet service
-# + return - The Google Wallet save URL, or an error if the operation fails
-public isolated function getGoogleSaveUrl(WalletCardRequest card, string jwtAssertion) returns GoogleSaveUrl|error {
-    GoogleSaveUrl saveUrl = check walletClient->post(GOOGLE_SAVE_URL_PATH, card,
-            {[authorization:JWT_ASSERTION_HEADER]: jwtAssertion});
+# + userToken - Access token of the caller, forwarded to the wallet service
+# + return - The Google Wallet save URL, or a `WalletError` carrying the upstream status and body
+public isolated function getGoogleSaveUrl(WalletCardRequest card, string userToken)
+    returns GoogleSaveUrl|WalletError {
+
+    http:Response response = check post(GOOGLE_SAVE_URL_PATH, card, userToken);
+    json|error payload = response.getJsonPayload();
+    if payload is error {
+        return error WalletError("Wallet service returned a non-JSON save URL response", payload,
+                statusCode = response.statusCode, body = payload.message());
+    }
+
+    GoogleSaveUrl|error saveUrl = payload.cloneWithType();
+    if saveUrl is error {
+        return error WalletError("Wallet service returned an unexpected save URL shape", saveUrl,
+                statusCode = response.statusCode, body = truncate(payload.toJsonString()));
+    }
+
+    log:printDebug("Wallet service returned a Google Wallet save URL", path = GOOGLE_SAVE_URL_PATH,
+            serialNumber = card.serialNumber);
     return saveUrl;
 }
+
+# POSTs a business card to the wallet service and rejects any non-2xx response.
+#
+# The response is taken as an `http:Response` rather than bound to a payload type so that a
+# failure keeps its status code and body; binding discards both and yields a bare
+# "Unauthorized"-style message that says nothing about which credential was rejected.
+#
+# + path - Wallet service path to call
+# + card - Business card fields to render on the pass
+# + userToken - Access token of the caller
+# + return - The successful response, or a `WalletError` describing the failure
+isolated function post(string path, WalletCardRequest card, string userToken)
+    returns http:Response|WalletError {
+
+    log:printDebug("Calling the wallet service", path = path, serialNumber = card.serialNumber,
+            hasJobTitle = card.hasKey("jobTitle"), hasMobile = card.hasKey("mobile"),
+            hasThumbnail = card.hasKey("employeeThumbnail"));
+
+    http:Response|error response = walletClient->post(path, card, headers(userToken));
+    if response is error {
+        // No response at all: DNS, TLS, connect timeout, or an unreachable wallet service.
+        log:printError("Could not reach the wallet service", response, path = path);
+        return error WalletError("Could not reach the wallet service", response,
+                statusCode = (), body = response.message());
+    }
+
+    if response.statusCode >= 200 && response.statusCode < 300 {
+        return response;
+    }
+
+    string body = errorBody(response);
+    log:printError("Wallet service rejected the request", path = path,
+            statusCode = response.statusCode, responseBody = body);
+    return error WalletError(string `Wallet service responded with ${response.statusCode}`,
+            statusCode = response.statusCode, body = body);
+}
+
+# Builds the headers forwarded to the wallet service.
+#
+# The wallet service authenticates on `Authorization` alone -- it ignores `x-jwt-assertion`,
+# and an application (client credentials) token is rejected as well, so this has to be the
+# caller's own user access token. `x-jwt-assertion` is still sent because the service reads
+# claims from it where present.
+#
+# + userToken - Access token of the caller
+# + return - Headers to send with the wallet service request
+isolated function headers(string userToken) returns map<string> => {
+    [AUTHORIZATION_HEADER]: BEARER_PREFIX + userToken,
+    [authorization:JWT_ASSERTION_HEADER]: userToken
+};
+
+# Reads the body of a failed wallet service response for logging.
+#
+# + response - Failed wallet service response
+# + return - The body text, or a placeholder when it cannot be read
+isolated function errorBody(http:Response response) returns string {
+    string|error body = response.getTextPayload();
+    return body is string ? truncate(body) : "<unreadable body>";
+}
+
+# Caps a string at `MAX_LOGGED_BODY_LENGTH` so one upstream failure cannot flood the log.
+#
+# + text - Text to cap
+# + return - The text, truncated with an ellipsis when it is too long
+isolated function truncate(string text) returns string =>
+    text.length() <= MAX_LOGGED_BODY_LENGTH ? text : text.substring(0, MAX_LOGGED_BODY_LENGTH) + "...";

--- a/backend/service.bal
+++ b/backend/service.bal
@@ -154,7 +154,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
     # + req - HTTP request, used to forward the caller's JWT assertion to the wallet service
     # + return - The `.pkpass` bytes, or an `http:InternalServerError` if the operation fails
     resource function get business\-card/pkpass(http:RequestContext ctx, http:Request req)
-        returns http:Response|http:InternalServerError {
+        returns http:Response|http:Unauthorized|http:BadGateway|http:InternalServerError {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -165,26 +165,22 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        string|error jwtAssertion = req.getHeader(authorization:JWT_ASSERTION_HEADER);
-        if jwtAssertion is error {
+        string|error userToken = authorization:getUserAccessToken(req);
+        if userToken is error {
             string customError = "Missing invoker info header!";
-            log:printError(customError, jwtAssertion);
-            return <http:InternalServerError>{
+            log:printError(customError, userToken);
+            return <http:Unauthorized>{
                 body: {
                     message: customError
                 }
             };
         }
 
-        byte[]|error pass = wallet:getApplePass(toWalletCardRequest(toBusinessCard(userInfo)), jwtAssertion);
-        if pass is error {
-            string customError = "Error occurred while generating the Apple Wallet pass!";
-            log:printError(customError, pass);
-            return <http:InternalServerError>{
-                body: {
-                    message: customError
-                }
-            };
+        log:printDebug("Building the Apple Wallet pass", userId = userInfo.userId);
+        byte[]|wallet:WalletError pass =
+            wallet:getApplePass(toWalletCardRequest(toBusinessCard(userInfo)), userToken);
+        if pass is wallet:WalletError {
+            return walletFailure("Apple Wallet pass", userInfo.userId, pass);
         }
 
         http:Response response = new;
@@ -200,7 +196,7 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
     # + req - HTTP request, used to forward the caller's JWT assertion to the wallet service
     # + return - The Google Wallet save URL, or an `http:InternalServerError` if the operation fails
     resource function get business\-card/google\-save\-url(http:RequestContext ctx, http:Request req)
-        returns wallet:GoogleSaveUrl|http:InternalServerError {
+        returns wallet:GoogleSaveUrl|http:Unauthorized|http:BadGateway|http:InternalServerError {
 
         authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
         if userInfo is error {
@@ -211,27 +207,22 @@ service http:InterceptableService / on new http:Listener(9090, config = {request
             };
         }
 
-        string|error jwtAssertion = req.getHeader(authorization:JWT_ASSERTION_HEADER);
-        if jwtAssertion is error {
+        string|error userToken = authorization:getUserAccessToken(req);
+        if userToken is error {
             string customError = "Missing invoker info header!";
-            log:printError(customError, jwtAssertion);
-            return <http:InternalServerError>{
+            log:printError(customError, userToken);
+            return <http:Unauthorized>{
                 body: {
                     message: customError
                 }
             };
         }
 
-        wallet:GoogleSaveUrl|error saveUrl = wallet:getGoogleSaveUrl(toWalletCardRequest(toBusinessCard(userInfo)),
-                jwtAssertion);
-        if saveUrl is error {
-            string customError = "Error occurred while generating the Google Wallet save URL!";
-            log:printError(customError, saveUrl);
-            return <http:InternalServerError>{
-                body: {
-                    message: customError
-                }
-            };
+        log:printDebug("Building the Google Wallet save URL", userId = userInfo.userId);
+        wallet:GoogleSaveUrl|wallet:WalletError saveUrl =
+            wallet:getGoogleSaveUrl(toWalletCardRequest(toBusinessCard(userInfo)), userToken);
+        if saveUrl is wallet:WalletError {
+            return walletFailure("Google Wallet save URL", userInfo.userId, saveUrl);
         }
 
         return saveUrl;

--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -18,6 +18,7 @@ import superapp_mobile_service.entity;
 import superapp_mobile_service.wallet;
 
 import ballerina/cache;
+import ballerina/http;
 import ballerina/log;
 
 final cache:Cache userInfoCache = new (capacity = 100, evictionFactor = 0.2);
@@ -105,4 +106,37 @@ isolated function toWalletCardRequest(BusinessCard card) returns wallet:WalletCa
     }
 
     return cardRequest;
+}
+
+# Maps a wallet service failure to the response the caller gets.
+#
+# The upstream status is what makes these distinguishable in the app and in the logs: an
+# expired token is the caller's problem (401) and is by far the most common cause, while
+# anything else is the wallet service failing on our behalf (502). Collapsing both into a
+# blanket 500 is what made this endpoint impossible to triage.
+#
+# + operation - What was being built, used in the log line
+# + userId - User the pass was being built for
+# + walletError - Failure returned by the wallet module
+# + return - `http:Unauthorized` when the wallet service rejected the token, else `http:BadGateway`
+public isolated function walletFailure(string operation, string userId, wallet:WalletError walletError)
+    returns http:Unauthorized|http:BadGateway {
+
+    int? statusCode = walletError.detail().statusCode;
+    log:printError(string `Error occurred while generating the ${operation}!`, walletError,
+            userId = userId, upstreamStatus = statusCode ?: -1, upstreamBody = walletError.detail().body);
+
+    if statusCode == http:STATUS_UNAUTHORIZED || statusCode == http:STATUS_FORBIDDEN {
+        return <http:Unauthorized>{
+            body: {
+                message: string `Not authorized to generate the ${operation}. Sign in again and retry.`
+            }
+        };
+    }
+
+    return <http:BadGateway>{
+        body: {
+            message: string `The wallet service could not generate the ${operation}.`
+        }
+    };
 }


### PR DESCRIPTION
## Problem

`GET /business-card/pkpass` and `/business-card/google-save-url` always fail with:

```json
{ "message": "Error occurred while generating the Apple Wallet pass!" }
```

Reproduced against the hosted staging backend, not just locally.

## Root cause

`modules/wallet/client.bal` assumed the wallet service accepts the caller's `x-jwt-assertion`. It does not — it authenticates on `Authorization` alone. Tested against `apis-stg`:

| Credential sent to the wallet service | Result |
| --- | --- |
| `x-jwt-assertion` only | 401 `900901 Invalid Credentials` — the bug |
| Client-credentials `Bearer` | 401 `{"message":"invalid token"}` — application tokens are rejected |
| Client-credentials `Bearer` + user `x-jwt-assertion` | 401 — the assertion is ignored entirely |
| User access token as `Authorization: Bearer` | **200, valid `.pkpass`** |

Hosted, this cannot work at all. The API gateway **overwrites** `x-jwt-assertion` with a JWT it mints itself — confirmed by sending `x-jwt-assertion: garbage.garbage.garbage` to the hosted `/user-info`, which still returned 200. So that header never carries a token another gateway-fronted API will accept.

## Fix

Read the caller's real access token from `x-user-assertion`, which the gateway passes through untouched — the same header the chat agent already uses for this reason.

- **`modules/authorization`** — `getUserAccessToken()` resolves the token from `x-user-assertion`, then `Authorization: Bearer`, then `x-jwt-assertion` (local development, where no gateway has rewritten it). Debug-logs which source was used.
- **`modules/wallet`** — sends `Authorization: Bearer <token>`, and keeps the upstream response as an `http:Response` so a failure retains its status code and body. Binding to a payload type discarded both, which is what made these 500s undiagnosable. New `WalletError` carries `statusCode` + `body`.
- **`service.bal` / `utils.bal`** — a wallet failure now maps to **401** when the token was rejected and **502** when the wallet service failed on our behalf, instead of one opaque 500.

Backend only. The app-side change that sends `x-user-assertion` is left to a separate PR.

## Verification

All three token sources return a valid pass, and a bad token no longer produces a 500:

```
x-user-assertion       -> 200, 109273 bytes, Zip (valid pkpass)
Authorization: Bearer  -> 200, 109270 bytes
x-jwt-assertion (dev)  -> 200, 109269 bytes
bad token              -> 401 "Not authorized... Sign in again and retry."
```

Failures now name the upstream reason:

```
level=ERROR message="Wallet service rejected the request" statusCode=401
  responseBody="{\"error_message\":\"Invalid Credentials\",\"code\":\"900901\",...}"
```

`bal build` clean.

## Deployment notes

- `walletServiceBaseUrl` must be set for the backend component — it is a required configurable and is currently absent from the deployed config.
- Until the app-side `x-user-assertion` PR ships, this path depends on the gateway forwarding the original `Authorization` header to the backend. That was not verifiable from a local machine; the fallback chain covers it either way.
- `Dependencies.toml` version bumps produced by `bal build` are deliberately excluded from this PR.

## Known divergence from the chat-agent pattern

The chat agent does not forward the raw user token downstream — it runs an RFC 8693 token exchange (`infrastructure/auth/token_exchange.py`) to mint a token scoped to the target micro-app first. This PR forwards the user's superapp token directly, which the wallet service accepts today. Aligning would need a wallet-service Asgardeo app registered (client ID + scope); raising it here rather than blocking the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)