### PR TITLE
[Open Super App] Fix micro-app download and login flows for external users

### DIFF
--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -15,7 +15,6 @@
 // under the License.
 import superapp_mobile_service.authorization;
 import superapp_mobile_service.entity;
-import superapp_mobile_service.scim;
 import superapp_mobile_service.wallet;
 
 import ballerina/cache;
@@ -29,10 +28,6 @@ final cache:Cache userInfoCache = new (capacity = 100, evictionFactor = 0.2);
 # + email - Email address of the user
 # + return - entity:Employee record if available, or error? if an error occurs or the user is not found
 public isolated function getUserInfo(string email) returns entity:Employee|error? {
-    if !scim:isInternalUser(email) {
-        return ();
-    }
-
     if userInfoCache.hasKey(email) {
         entity:Employee|error loggedInUser = userInfoCache.get(email).ensureType();
         if loggedInUser is error {

--- a/backend/utils.bal
+++ b/backend/utils.bal
@@ -15,6 +15,7 @@
 // under the License.
 import superapp_mobile_service.authorization;
 import superapp_mobile_service.entity;
+import superapp_mobile_service.scim;
 import superapp_mobile_service.wallet;
 
 import ballerina/cache;
@@ -28,6 +29,10 @@ final cache:Cache userInfoCache = new (capacity = 100, evictionFactor = 0.2);
 # + email - Email address of the user
 # + return - entity:Employee record if available, or error? if an error occurs or the user is not found
 public isolated function getUserInfo(string email) returns entity:Employee|error? {
+    if !scim:isInternalUser(email) {
+        return ();
+    }
+
     if userInfoCache.hasKey(email) {
         entity:Employee|error loggedInUser = userInfoCache.get(email).ensureType();
         if loggedInUser is error {

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -21,7 +21,9 @@ import {
   APP_LIST_CONFIG_KEY,
   APP_UPDATE_CHECK_TIMESTAMP_KEY,
   DOWNLOADED,
+  MICRO_APP_STORAGE_DIR,
 } from "@/constants/Constants";
+import { Directory, Paths } from "expo-file-system";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { MicroApp } from "@/context/slices/appSlice";
 import { getUserConfigurations } from "@/context/slices/userConfigSlice";
@@ -209,11 +211,17 @@ export default function HomeScreen() {
 
         const allowedApps = (userConfigAppIds?.configValue as string[]) || [];
 
-        const localApps: MicroApp[] = apps.filter(
-          (app) => app?.status === DOWNLOADED
-        );
+        // Verify if the files actually exist on disk, not just trust the Redux status
+        const localAppIds: string[] = [];
+        for (const app of apps) {
+          if (app?.status === DOWNLOADED) {
+             const appDir = new Directory(Paths.document, MICRO_APP_STORAGE_DIR, "micro-apps", `${app.appId}-extracted`);
+             if (appDir.exists) {
+                localAppIds.push(app.appId);
+             }
+          }
+        }
 
-        const localAppIds = localApps.map((app) => app.appId);
         const appsToRemove = localAppIds.filter(
           (appId) => !allowedApps.includes(appId)
         );
@@ -232,8 +240,8 @@ export default function HomeScreen() {
           setProgress((prev) => ({ ...prev, done: prev.done + 1 }));
         }
 
-        let updatedApps = localApps.filter(
-          (app) => !appsToRemove.includes(app.appId)
+        let updatedApps = apps.filter(
+          (app) => localAppIds.includes(app.appId) && !appsToRemove.includes(app.appId)
         );
 
         // Install apps

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -273,8 +273,8 @@ export default function HomeScreen() {
       }
     };
 
-    if (userConfigurations && userConfigurations.length > 0) syncApps();
-  }, [dispatch, userConfigurations]);
+    if (userConfigurations && userConfigurations.length > 0 && apps && apps.length > 0) syncApps();
+  }, [dispatch, userConfigurations, apps]);
 
   // Filter apps based on search query
   useEffect(() => {

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -249,16 +249,19 @@ export default function HomeScreen() {
           const appData = apps.find((app) => app.appId === appId);
           if (appData) {
             setCurrentAction(`Downloading ${appData.name}`);
-            await downloadMicroApp(
+            const success = await downloadMicroApp(
               dispatch,
               appId,
               appData.versions?.[0]?.downloadUrl,
               logout
             );
-            updatedApps.push({
-              ...appData,
-              status: DOWNLOADED,
-            });
+            
+            if (success) {
+              updatedApps.push({
+                ...appData,
+                status: DOWNLOADED,
+              });
+            }
             setProgress((prev) => ({ ...prev, done: prev.done + 1 }));
           }
         }

--- a/frontend/context/slices/userConfigSlice.ts
+++ b/frontend/context/slices/userConfigSlice.ts
@@ -82,7 +82,11 @@ export const getUserConfigurations = createAsyncThunk(
 const userConfigSlice = createSlice({
   name: "userConfig",
   initialState,
-  reducers: {},
+  reducers: {
+    clearUserConfigurations: (state) => {
+      state.configurations = [];
+    },
+  },
   extraReducers: (builder) => {
     builder
       .addCase(getUserConfigurations.pending, (state) => {
@@ -97,5 +101,7 @@ const userConfigSlice = createSlice({
       });
   },
 });
+
+export const { clearUserConfigurations } = userConfigSlice.actions;
 
 export default userConfigSlice.reducer;

--- a/frontend/context/slices/userInfoSlice.ts
+++ b/frontend/context/slices/userInfoSlice.ts
@@ -52,8 +52,8 @@ export const getUserInfo = createAsyncThunk(
 
       if (response?.status === 200) return response.data;
       else return rejectWithValue("User info not found");
-    } catch (error) {
-      return rejectWithValue(error);
+    } catch (error: any) {
+      return rejectWithValue(error?.message || "Error fetching user info");
     }
   }
 );

--- a/frontend/services/appStoreService.ts
+++ b/frontend/services/appStoreService.ts
@@ -73,8 +73,7 @@ export const downloadMicroApp = async (
     dispatch(updateDownloadProgress({ appId, progress: 0 })); // Initialize progress
 
     if (!downloadUrl) {
-      Alert.alert("Error", "Download URL is empty.");
-      return false;
+      throw new Error("Download URL is empty.");
     }
 
     await downloadAndSaveFile(dispatch, appId, downloadUrl); // Download react production build
@@ -120,7 +119,6 @@ const unzipFile = async (dispatch: AppDispatch, appId: string) => {
     const extractedDir = new Directory(microAppsDir, `${appId}-extracted`);
 
     if (!zipFile.exists || zipFile.size === 0) {
-      Alert.alert("Error", "ZIP file not found or is empty.");
       throw new Error("ZIP file not found or is empty.");
     }
 

--- a/frontend/services/appStoreService.ts
+++ b/frontend/services/appStoreService.ts
@@ -67,14 +67,14 @@ export const downloadMicroApp = async (
   appId: string,
   downloadUrl: string | null,
   onLogout: () => Promise<void>
-) => {
+): Promise<boolean> => {
   try {
     dispatch(addDownloading(appId)); // Downloading status for indicator
     dispatch(updateDownloadProgress({ appId, progress: 0 })); // Initialize progress
 
     if (!downloadUrl) {
       Alert.alert("Error", "Download URL is empty.");
-      return;
+      return false;
     }
 
     await downloadAndSaveFile(dispatch, appId, downloadUrl); // Download react production build
@@ -85,9 +85,12 @@ export const downloadMicroApp = async (
 
     await UpdateUserConfiguration(appId, DOWNLOADED, onLogout); // Update user configurations
     dispatch(updateDownloadProgress({ appId, progress: 100 }));
+    
+    return true;
   } catch (error) {
     await UpdateUserConfiguration(appId, NOT_DOWNLOADED, onLogout); // Update user configurations
     Alert.alert("Error", "Failed to download or save the file.");
+    return false;
   } finally {
     dispatch(removeDownloading(appId));
   }
@@ -118,7 +121,7 @@ const unzipFile = async (dispatch: AppDispatch, appId: string) => {
 
     if (!zipFile.exists || zipFile.size === 0) {
       Alert.alert("Error", "ZIP file not found or is empty.");
-      return;
+      throw new Error("ZIP file not found or is empty.");
     }
 
     const zipContent = await zipFile.base64();

--- a/frontend/utils/microAppCacheStore.ts
+++ b/frontend/utils/microAppCacheStore.ts
@@ -17,6 +17,7 @@ import {
   APPS,
   LAST_LOGGED_IN_USER_ID_KEY,
   MICRO_APP_STORAGE_DIR,
+  USER_CONFIGURATIONS,
 } from "@/constants/Constants";
 import { setApps } from "@/context/slices/appSlice";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -36,6 +37,7 @@ const clearDownloadedMicroApps = async (dispatch: Dispatch<UnknownAction>) => {
     microAppsDir.delete();
   }
   await AsyncStorage.removeItem(APPS);
+  await AsyncStorage.removeItem(USER_CONFIGURATIONS);
   dispatch(setApps([]));
 };
 

--- a/frontend/utils/microAppCacheStore.ts
+++ b/frontend/utils/microAppCacheStore.ts
@@ -20,6 +20,7 @@ import {
   USER_CONFIGURATIONS,
 } from "@/constants/Constants";
 import { setApps } from "@/context/slices/appSlice";
+import { clearUserConfigurations } from "@/context/slices/userConfigSlice";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { Dispatch, UnknownAction } from "@reduxjs/toolkit";
 import { Directory, Paths } from "expo-file-system";
@@ -39,6 +40,7 @@ const clearDownloadedMicroApps = async (dispatch: Dispatch<UnknownAction>) => {
   await AsyncStorage.removeItem(APPS);
   await AsyncStorage.removeItem(USER_CONFIGURATIONS);
   dispatch(setApps([]));
+  dispatch(clearUserConfigurations());
 };
 
 // Keeps a signed-in user's downloaded micro-apps across logout/login so the


### PR DESCRIPTION
Closes https://github.com/wso2-enterprise/wso2-digital-team-project-management/issues/1128

### Summary of Changes
This PR resolves multiple critical issues blocking external users (such as standard Google/Gmail accounts) from logging in, navigating profiles, and launching micro-apps.

---
### Key Changes & Fixes

**1. Fixed Redux State Mutation Crash on 404 Responses**
* **File:** `frontend/context/slices/userInfoSlice.ts`
* **Issue:** When the profile endpoint returned a 404, the Redux Thunk caught the raw `AxiosError` object and passed it to the store, triggering a runtime crash (*"A state mutation was detected between dispatches"*).
* **Fix:** Updated the `catch` handler to pass a serializable string message (`error?.message`) instead of the raw error object.

**2. Prevented Stale App State During Account Switching**
* **Files:** `frontend/utils/microAppCacheStore.ts`, `frontend/context/slices/userConfigSlice.ts`
* **Issue:** Switching between accounts wiped downloaded app files and the `APPS` cache but left `USER_CONFIGURATIONS` in persistent storage and active Redux memory, causing new accounts to inherit the previous account's configuration.
* **Fix:** Added `AsyncStorage.removeItem(USER_CONFIGURATIONS)` and dispatched a newly created `clearUserConfigurations()` reducer during cache teardown to ensure a clean state reset across user sessions.

**3. Resolved "Ghost App" Code 300 WebView Crashes**
* **File:** `frontend/app/(tabs)/apps/index.tsx`
* **Issue:** The app relied solely on the Redux `DOWNLOADED` status. If local files were cleared (e.g., simulator reset, cache clear), the app skipped re-downloading, resulting in a Code 300 crash when opening non-existent files.
* **Fix:** Added a filesystem check (`appDir.exists`) via `expo-file-system` to verify extracted files on disk before treating an app as installed, forcing a fresh download if assets are missing.

**4. Fixed Redux State Desync on Download Failures**
* **Files:** `frontend/services/appStoreService.ts`, `frontend/app/(tabs)/apps/index.tsx`
* **Issue:** Failed app downloads or unzips (e.g., 0-byte zip files) were silently caught while the UI still updated the Redux status to `DOWNLOADED`, resulting in unusable "ghost" apps in the list.
* **Fix:** Updated `downloadMicroApp` to return a boolean for success/failure, made `unzipFile` explicitly throw errors on empty files, and ensured `syncApps` checks the boolean result before pushing the `DOWNLOADED` state to Redux.

**5. Fixed syncApps Race Condition (Auto-Download Bug)**
* **File:** `frontend/app/(tabs)/apps/index.tsx`
* **Issue:** The app synchronization effect could trigger before the micro-apps array was populated from the API, causing default micro-apps to silently skip downloading on first login until the page was refreshed.
* **Fix:** Added `apps` to the `syncApps` dependency array along with an `apps.length > 0` guard to ensure download synchronization only runs after both user configurations and app data are fully loaded.

**6. Improved Download Error Cleanup & Alert Handling**
* **File:** `frontend/services/appStoreService.ts`
* **Issue:** Empty download URLs caused an infinite retry loop because returning `false` bypassed the failure cleanup block. In addition, missing ZIP files triggered multiple overlapping error alerts.
* **Fix:** Changed empty URL handling to throw an error (ensuring the `catch` block correctly calls `UpdateUserConfiguration` with `NOT_DOWNLOADED`) and removed redundant alerts in `unzipFile` so the parent `catch` block owns the single UI notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of downloaded micro-apps, ensuring only successfully extracted apps are shown as available.
  * Failed or incomplete downloads are no longer treated as installed.
  * Improved error messages when user information cannot be retrieved.
  * Download failures now properly surface instead of being silently ignored.
  * Clearing the micro-app cache now also removes saved user configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->