### PR TITLE
[Frontend] Bugfix: Keep Redux user configurations in step with storage

### DIFF
--- a/frontend/context/slices/userConfigSlice.ts
+++ b/frontend/context/slices/userConfigSlice.ts
@@ -17,7 +17,7 @@ import { BASE_URL, USER_CONFIGURATIONS } from "@/constants/Constants";
 import { removeDuplicatesFromUserConfigs } from "@/utils/removeDuplicates";
 import { apiRequest } from "@/utils/requestHandler";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
 interface AppArrangement {
   name: string;
@@ -86,6 +86,27 @@ const userConfigSlice = createSlice({
     clearUserConfigurations: (state) => {
       state.configurations = [];
     },
+    // Mirrors a single config entry that has already been written to
+    // AsyncStorage/the server back into Redux, so in-memory readers don't work
+    // off a boot-time snapshot. Only the named key is touched; every other
+    // entry (and its uuid) is left as-is.
+    setUserConfigValue: (
+      state,
+      action: PayloadAction<{
+        configKey: string;
+        configValue: UserConfig["configValue"];
+      }>
+    ) => {
+      const { configKey, configValue } = action.payload;
+      const existing = state.configurations.find(
+        (config) => config.configKey === configKey
+      );
+      if (existing) {
+        existing.configValue = configValue;
+      } else {
+        state.configurations.push({ configKey, configValue, isActive: 1 });
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -102,6 +123,7 @@ const userConfigSlice = createSlice({
   },
 });
 
-export const { clearUserConfigurations } = userConfigSlice.actions;
+export const { clearUserConfigurations, setUserConfigValue } =
+  userConfigSlice.actions;
 
 export default userConfigSlice.reducer;

--- a/frontend/services/userConfigService.ts
+++ b/frontend/services/userConfigService.ts
@@ -19,7 +19,10 @@ import {
   DOWNLOADED,
   USER_CONFIGURATIONS,
 } from "@/constants/Constants";
-import { UserConfig } from "@/context/slices/userConfigSlice";
+import {
+  setUserConfigValue,
+  UserConfig,
+} from "@/context/slices/userConfigSlice";
 import { store } from "@/context/store";
 import { apiRequest } from "@/utils/requestHandler";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -67,8 +70,10 @@ export const UpdateUserConfiguration = async (
       return;
     }
 
-    let updatedConfigValue = Array.isArray(appUserConfigs.configValue)
-      ? [...appUserConfigs.configValue]
+    // The app-list config is always a string[] of appIds; annotate so the value
+    // can be handed to the typed reducer below. No runtime change.
+    let updatedConfigValue: string[] = Array.isArray(appUserConfigs.configValue)
+      ? [...(appUserConfigs.configValue as string[])]
       : [];
 
     if (action === DOWNLOADED) {
@@ -88,6 +93,15 @@ export const UpdateUserConfiguration = async (
     await AsyncStorage.setItem(
       USER_CONFIGURATIONS,
       JSON.stringify(updatedUserConfigs)
+    );
+    // Keep Redux in step with the write above. Without this, readers such as
+    // the My Apps sync effect keep using the boot-time snapshot and treat a
+    // just-downloaded app as one the user is no longer entitled to.
+    store.dispatch(
+      setUserConfigValue({
+        configKey: APP_LIST_CONFIG_KEY,
+        configValue: updatedConfigValue,
+      })
     );
     const state = store.getState();
     const userId = state.auth.userId;
@@ -121,6 +135,12 @@ export const UpdateUserConfiguration = async (
       await AsyncStorage.setItem(
         USER_CONFIGURATIONS,
         JSON.stringify(storedUserConfigs)
+      );
+      store.dispatch(
+        setUserConfigValue({
+          configKey: APP_LIST_CONFIG_KEY,
+          configValue: appUserConfigs.configValue,
+        })
       );
     }
 


### PR DESCRIPTION
## Purpose

`UpdateUserConfiguration` wrote the app list to AsyncStorage and to the server, but never told Redux. Every in-memory reader kept working off the boot-time snapshot — so a just-downloaded app still looked un-entitled.

## Approach

1. New `setUserConfigValue` reducer on `userConfigSlice` — updates one config key in place, leaves every other entry untouched.
2. `userConfigService` dispatches it right after the AsyncStorage write, and again on the server-failure rollback path.

2 files, +47 / -5. Nothing outside the app-list config key changes.

## Not in this PR

The sync effect that was consuming the stale value. That's #83, stacked on top of this one.

## Release note

Fixed micro-app entitlements going stale in memory after a download or removal.

## Automation tests

- No existing suite covers these two files.
- Full frontend suite: **155 / 155 passing**.
- `tsc --noEmit`: no new errors.

## Security checks

- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Documentation

N/A — internal state handling, no user-facing behaviour change.
