### PR TITLE
[Frontend] Bugfix: Stop My Apps racing in-flight micro-app downloads

### DIFF
--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -60,6 +60,7 @@ export default function HomeScreen() {
   const downloadProgress = useSelector(
     (state: RootState) => state.apps.downloadProgress
   );
+  const downloading = useSelector((state: RootState) => state.apps.downloading);
   const { userId } = useSelector((state: RootState) => state.auth);
   const isForceUpdate = useSelector(
     (state: RootState) =>
@@ -88,6 +89,10 @@ export default function HomeScreen() {
   });
   const [updatingApps, setUpdatingApps] = useState<string[]>([]);
   const isCheckingUpdates = useRef(false);
+  // Mirrored into a ref so syncApps can read the in-flight download set without
+  // adding it to the effect's dependencies (which would change when syncApps runs).
+  const downloadingRef = useRef<string[]>(downloading);
+  downloadingRef.current = downloading;
   useTrackActiveScreen(ScreenPaths.MY_APPS);
   const updateCheckInterval = useSelector(
     (state: RootState) =>
@@ -222,11 +227,16 @@ export default function HomeScreen() {
           }
         }
 
+        // A download in flight has already written its files and status, but
+        // has not yet recorded its entitlement. Leave those apps alone so this
+        // effect never removes or re-downloads an app it raced with.
+        const inFlight = downloadingRef.current;
+
         const appsToRemove = localAppIds.filter(
-          (appId) => !allowedApps.includes(appId)
+          (appId) => !allowedApps.includes(appId) && !inFlight.includes(appId)
         );
         const appsToInstall = allowedApps.filter(
-          (appId) => !localAppIds.includes(appId)
+          (appId) => !localAppIds.includes(appId) && !inFlight.includes(appId)
         );
 
         const totalSteps = appsToRemove.length + appsToInstall.length;

--- a/frontend/services/appStoreService.ts
+++ b/frontend/services/appStoreService.ts
@@ -247,6 +247,11 @@ export const removeMicroApp = async (
       zipFile.delete();
     }
 
+    // Drop the entitlement before flipping the status. The status dispatch
+    // re-triggers the My Apps sync effect, which would otherwise still see this
+    // app as entitled but missing from disk and immediately re-download it.
+    await UpdateUserConfiguration(appId, NOT_DOWNLOADED, onLogout); // Update user configurations
+
     dispatch(
       updateAppStatus({
         appId,
@@ -258,7 +263,6 @@ export const removeMicroApp = async (
         displayMode: DEFAULT_VIEWING_MODE,
       })
     );
-    await UpdateUserConfiguration(appId, NOT_DOWNLOADED, onLogout); // Update user configurations
   } catch (error) {
     Alert.alert("Error", "Failed to remove the app.");
   }


### PR DESCRIPTION
## Purpose

Removing or re-downloading a micro-app could race the My Apps sync effect, which then deleted or re-downloaded the very app it had raced with.

## Approach

1. `apps/index.tsx` — the sync effect now skips apps with a download in flight. The in-flight ids are mirrored into a ref, so reading them doesn't re-run the effect.
2. `appStoreService.removeMicroApp` — drops the entitlement **before** flipping app status. The status dispatch re-triggers the sync effect, which previously still saw the app as entitled but missing from disk, and immediately re-downloaded it.

2 files, +17 / -3.

## Stacked on

#82 — makes Redux the live source this guard reads from. Merge that first.

## Release note

Fixed micro-apps being removed or re-downloaded while a download was still in flight.

## Automation tests

- No existing suite covers these two files.
- Full frontend suite: **155 / 155 passing**.
- `tsc --noEmit`: no new errors.

## Security checks

- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Documentation

N/A — internal sync behaviour, no user-facing behaviour change.
